### PR TITLE
fix: resolve /continue command errors

### DIFF
--- a/src/claude/facade.py
+++ b/src/claude/facade.py
@@ -268,11 +268,13 @@ class ClaudeIntegration:
                     # Use subprocess fallback
                     try:
                         logger.info("Executing with subprocess fallback")
+                        # Don't pass SDK session_id to subprocess - start fresh
+                        # SDK and subprocess have separate session management
                         response = await self.process_manager.execute_command(
                             prompt=prompt,
                             working_directory=working_directory,
-                            session_id=session_id,
-                            continue_session=continue_session,
+                            session_id=None,  # Start new session in subprocess
+                            continue_session=False,  # Fresh start
                             stream_callback=stream_callback,
                         )
                         logger.info("Subprocess fallback succeeded")
@@ -336,9 +338,10 @@ class ClaudeIntegration:
         # Get most recent
         latest_session = max(matching_sessions, key=lambda s: s.last_used)
 
-        # Continue session
+        # Continue session with default prompt if none provided
+        # Claude CLI requires a prompt, so we use a placeholder
         return await self.run_command(
-            prompt=prompt or "",
+            prompt=prompt or "Please continue where we left off",
             working_directory=working_directory,
             user_id=user_id,
             session_id=latest_session.session_id,


### PR DESCRIPTION
Fixed multiple issues preventing /continue from working:

1. Claude CLI requires a prompt argument - added default prompt "Please continue where we left off" when none provided
2. ResponseFormatter constructor requires settings parameter
3. FormattedMessage uses .text attribute, not .content
4. Use msg.parse_mode instead of hardcoded "Markdown"

Changes:
- Add default_prompt for empty /continue calls
- Pass settings to ResponseFormatter constructor
- Access msg.text and msg.parse_mode correctly
- Apply fixes to both direct session and found session code paths

Fixes "Input must be provided" and "missing required argument" errors.