### PR TITLE
fix: escape markdown in error messages for Telegram

### DIFF
--- a/src/bot/handlers/message.py
+++ b/src/bot/handlers/message.py
@@ -120,9 +120,16 @@ def _format_error_message(error_str: str) -> str:
         )
     else:
         # Generic error handling
+        # Escape special markdown characters in error message
+        # Replace problematic chars that break Telegram markdown
+        safe_error = error_str.replace("_", "\\_").replace("*", "\\*").replace("`", "\\`").replace("[", "\\[")
+        # Truncate very long errors
+        if len(safe_error) > 200:
+            safe_error = safe_error[:200] + "..."
+
         return (
             f"❌ **Claude Code Error**\n\n"
-            f"Failed to process your request: {error_str}\n\n"
+            f"Failed to process your request: {safe_error}\n\n"
             f"Please try again or contact the administrator if the problem persists."
         )
 


### PR DESCRIPTION
Error messages containing JSON or special markdown characters break Telegram's markdown parser with "Can't parse entities" errors.

Changes:
- Escape special markdown characters (_, *, `, [) in error messages
- Truncate very long error messages to 200 characters
- Prevents Telegram parse errors while preserving error visibility

Fixes Telegram markdown parsing errors when displaying error messages.