### PR TITLE
Fix: session context persistence

### DIFF
--- a/src/claude/session.py
+++ b/src/claude/session.py
@@ -41,6 +41,7 @@ class ClaudeSession:
     message_count: int = 0
     tools_used: List[str] = field(default_factory=list)
     is_new_session: bool = False  # True if session hasn't been sent to Claude Code yet
+    backend: Optional[str] = None  # Track which backend created this session ('sdk' or 'subprocess')
 
     def is_expired(self, timeout_hours: int) -> bool:
         """Check if session has expired."""


### PR DESCRIPTION
Fixed two critical issues causing conversation context to reset on every message:

1. Session continuation detection: Replaced unreliable `is_new_session` flag with robust `temp_` prefix check
   - The `is_new_session` flag persisted incorrectly in cached session objects
   - Now checks if session_id starts with "temp_" to determine if it's a new session
   - Ensures `--resume` flag is properly used for continuing conversations

2. Backend consistency: Added backend tracking to prevent SDK/subprocess session conflicts
   - SDK and subprocess have separate session storage and cannot resume each other's sessions
   - Added `backend` field to ClaudeSession to track which backend created each session
   - Sessions now stick with their original backend (SDK or subprocess) for their lifetime
   - Prevents context loss when SDK fails and falls back to subprocess

Before this fix:
- First message: Creates session (subprocess fallback due to SDK error)
- Second message: SDK tries to resume subprocess session → fails → context lost

After this fix:
- First message: Creates session with backend='subprocess'
- Second message: Uses subprocess directly → context maintained ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)