### PR TITLE
Fix env list validators for single values and missing tools parser

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -156,8 +156,26 @@ class Settings(BaseSettings):
     @classmethod
     def parse_allowed_users(cls, v: Any) -> Optional[List[int]]:
         """Parse comma-separated user IDs."""
+        if v is None:
+            return None
+        if isinstance(v, int):
+            return [v]
         if isinstance(v, str):
             return [int(uid.strip()) for uid in v.split(",") if uid.strip()]
+        if isinstance(v, list):
+            return [int(uid) for uid in v]
+        return v  # type: ignore[no-any-return]
+
+    @field_validator("claude_allowed_tools", mode="before")
+    @classmethod
+    def parse_claude_allowed_tools(cls, v: Any) -> Optional[List[str]]:
+        """Parse comma-separated tool names."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            return [tool.strip() for tool in v.split(",") if tool.strip()]
+        if isinstance(v, list):
+            return [str(tool) for tool in v]
         return v  # type: ignore[no-any-return]
 
     @field_validator("approved_directory")


### PR DESCRIPTION
Copying the default `.env.example` file didn't work for me. 

1. allowed_users: The validator only handled string input, assuming comma-separated values like in .env.example (ALLOWED_USERS=123,456). However, when a single user ID is specified (ALLOWED_USERS=901495888), pydantic-settings parses it as an int, not a string. The validator now handles int, string, and list inputs.

2. claude_allowed_tools: No validator existed at all. The field expected List[str] but received the raw comma-separated string from .env, causing a validation error. Added a new validator to parse comma-separated tool names.