### PR TITLE
Add MCP server support with configuration validation

### DIFF
--- a/src/claude/exceptions.py
+++ b/src/claude/exceptions.py
@@ -31,6 +31,14 @@ class ClaudeSessionError(ClaudeError):
     pass
 
 
+class ClaudeMCPError(ClaudeError):
+    """MCP server connection or configuration error."""
+
+    def __init__(self, message: str, server_name: str = None):
+        super().__init__(message)
+        self.server_name = server_name
+
+
 class ClaudeToolValidationError(ClaudeError):
     """Tool validation failed during Claude execution."""
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for Model Context Protocol (MCP) servers to the Claude integration, including configuration validation, error handling, and proper integration with both the SDK and CLI execution paths.

## Key Changes

### New Exception Type
- Added `ClaudeMCPError` exception class for MCP-specific errors with optional server name tracking

### Configuration Validation
- Enhanced `validate_mcp_config()` in settings to validate MCP configuration files:
  - Checks for valid JSON format
  - Ensures `mcpServers` key exists in config
  - Validates that `mcpServers` is a non-empty object mapping server names to configurations
  - Provides clear error messages for each validation failure

### SDK Integration
- Added MCP server configuration passing to `ClaudeCodeOptions` when MCP is enabled
- Implemented MCP-specific error detection in both `ProcessError` and `CLIConnectionError` handlers
- Errors containing "mcp" or "server" keywords are now raised as `ClaudeMCPError` for better error categorization

### CLI Integration
- Added `--mcp-config` command-line argument when building Claude Code commands with MCP enabled
- Implemented MCP error detection in process output handling

### Testing
- Added helper functions `_make_assistant_message()` and `_make_result_message()` to reduce test boilerplate
- Added comprehensive MCP configuration tests:
  - Test that MCP config is passed when enabled
  - Test that MCP config is not set when disabled
  - Test MCP-specific error handling for connection and process errors
- Enhanced existing config validation tests to cover all MCP validation scenarios

## Implementation Details
- MCP configuration is only passed to Claude when both `enable_mcp=True` and `mcp_config_path` is set
- MCP errors are distinguished from generic Claude errors for better debugging and user feedback
- Configuration validation happens at settings initialization time, preventing invalid configs from being used
- The implementation supports both SDK-based and CLI-based execution paths

https://claude.ai/code/session_012QUoPzDDNHCj8T5oEEyKJv