### PR TITLE
Fix: APPROVED_DIRECTORY doesn't restrict Bash tool

### DIFF
--- a/src/claude/facade.py
+++ b/src/claude/facade.py
@@ -120,7 +120,7 @@ class ClaudeIntegration:
                         )
 
                         # For critical tools, we should fail fast
-                        if tool_name in ["Task", "Read", "Write", "Edit"]:
+                        if tool_name in ["Task", "Read", "Write", "Edit", "Bash"]:
                             # Create comprehensive error message
                             admin_instructions = self._get_admin_instructions(
                                 list(blocked_tools)

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -177,6 +177,15 @@ class ClaudeSDKManager:
                 cwd=str(working_directory),
                 allowed_tools=self.config.claude_allowed_tools,
                 cli_path=cli_path,
+                sandbox={
+                    "enabled": self.config.sandbox_enabled,
+                    "autoAllowBashIfSandboxed": True,
+                    "excludedCommands": self.config.sandbox_excluded_commands or [],
+                },
+                system_prompt=(
+                    f"All file operations must stay within {working_directory}. "
+                    "Use relative paths."
+                ),
             )
 
             # Pass MCP server configuration if enabled

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -98,6 +98,16 @@ class Settings(BaseSettings):
         description="List of explicitly disallowed Claude tools/commands",
     )
 
+    # Sandbox settings
+    sandbox_enabled: bool = Field(
+        True,
+        description="Enable OS-level bash sandboxing to restrict commands to approved directory",
+    )
+    sandbox_excluded_commands: Optional[List[str]] = Field(
+        default=["git", "npm", "pip", "poetry", "make", "docker"],
+        description="Commands that run outside the sandbox (need system access)",
+    )
+
     # Rate limiting
     rate_limit_requests: int = Field(
         DEFAULT_RATE_LIMIT_REQUESTS, description="Requests per window"

--- a/tests/unit/test_claude/test_monitor.py
+++ b/tests/unit/test_claude/test_monitor.py
@@ -1,0 +1,165 @@
+"""Test Claude tool monitor — especially bash directory boundary checking."""
+
+from pathlib import Path
+
+import pytest
+
+from src.claude.monitor import ToolMonitor, check_bash_directory_boundary
+from src.config.settings import Settings
+
+
+class TestCheckBashDirectoryBoundary:
+    """Test the check_bash_directory_boundary function."""
+
+    def setup_method(self) -> None:
+        self.approved = Path("/root/projects")
+        self.cwd = Path("/root/projects/myapp")
+
+    def test_mkdir_outside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "mkdir -p /root/web1", self.cwd, self.approved
+        )
+        assert not valid
+        assert "directory boundary violation" in error.lower()
+        assert "/root/web1" in error
+
+    def test_mkdir_inside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "mkdir -p /root/projects/newdir", self.cwd, self.approved
+        )
+        assert valid
+        assert error is None
+
+    def test_touch_outside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "touch /tmp/evil.txt", self.cwd, self.approved
+        )
+        assert not valid
+        assert "/tmp/evil.txt" in error
+
+    def test_cp_outside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "cp file.txt /etc/passwd", self.cwd, self.approved
+        )
+        assert not valid
+        assert "/etc/passwd" in error
+
+    def test_mv_outside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "mv /root/projects/file.txt /tmp/file.txt", self.cwd, self.approved
+        )
+        assert not valid
+        assert "/tmp/file.txt" in error
+
+    def test_relative_paths_always_pass(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "mkdir -p subdir/nested", self.cwd, self.approved
+        )
+        assert valid
+        assert error is None
+
+    def test_read_only_commands_pass(self) -> None:
+        for cmd in ["cat /etc/hosts", "ls /tmp", "head /var/log/syslog"]:
+            valid, error = check_bash_directory_boundary(cmd, self.cwd, self.approved)
+            assert valid, f"Expected read-only command to pass: {cmd}"
+            assert error is None
+
+    def test_non_fs_commands_pass(self) -> None:
+        """Commands not in the filesystem-modifying set pass through."""
+        for cmd in ["python script.py", "node app.js", "cargo build"]:
+            valid, error = check_bash_directory_boundary(cmd, self.cwd, self.approved)
+            assert valid, f"Expected non-fs command to pass: {cmd}"
+            assert error is None
+
+    def test_empty_command(self) -> None:
+        valid, error = check_bash_directory_boundary("", self.cwd, self.approved)
+        assert valid
+        assert error is None
+
+    def test_flags_are_skipped(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "mkdir -p -v /root/projects/dir", self.cwd, self.approved
+        )
+        assert valid
+        assert error is None
+
+    def test_unparseable_command_passes_through(self) -> None:
+        """Malformed quoting should pass through (sandbox catches it at OS level)."""
+        valid, error = check_bash_directory_boundary(
+            "mkdir 'unclosed quote", self.cwd, self.approved
+        )
+        assert valid
+        assert error is None
+
+    def test_rm_outside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "rm /var/tmp/somefile", self.cwd, self.approved
+        )
+        assert not valid
+        assert "/var/tmp/somefile" in error
+
+    def test_ln_outside_approved_directory(self) -> None:
+        valid, error = check_bash_directory_boundary(
+            "ln -s /root/projects/file /tmp/link", self.cwd, self.approved
+        )
+        assert not valid
+        assert "/tmp/link" in error
+
+
+class TestToolMonitorBashBoundary:
+    """Test that validate_tool_call wires up the bash directory boundary check."""
+
+    @pytest.fixture
+    def config(self, tmp_path: Path) -> Settings:
+        return Settings(
+            telegram_bot_token="test:token",
+            telegram_bot_username="testbot",
+            approved_directory=tmp_path,
+            use_sdk=True,
+        )
+
+    @pytest.fixture
+    def monitor(self, config: Settings) -> ToolMonitor:
+        return ToolMonitor(config)
+
+    async def test_bash_directory_violation_recorded(
+        self, monitor: ToolMonitor, tmp_path: Path
+    ) -> None:
+        """Bash command writing outside approved dir is caught by validate_tool_call."""
+        valid, error = await monitor.validate_tool_call(
+            tool_name="Bash",
+            tool_input={"command": "mkdir -p /tmp/evil"},
+            working_directory=tmp_path,
+            user_id=123,
+        )
+        assert not valid
+        assert "directory boundary violation" in error.lower()
+        assert len(monitor.security_violations) == 1
+        assert monitor.security_violations[0]["type"] == "directory_boundary_violation"
+
+    async def test_bash_inside_approved_dir_passes(
+        self, monitor: ToolMonitor, tmp_path: Path
+    ) -> None:
+        """Bash command within approved dir passes validation."""
+        subdir = tmp_path / "subdir"
+        valid, error = await monitor.validate_tool_call(
+            tool_name="Bash",
+            tool_input={"command": f"mkdir -p {subdir}"},
+            working_directory=tmp_path,
+            user_id=123,
+        )
+        assert valid
+        assert error is None
+
+    async def test_dangerous_pattern_still_checked_first(
+        self, monitor: ToolMonitor, tmp_path: Path
+    ) -> None:
+        """Dangerous patterns are still caught before directory boundary check."""
+        valid, error = await monitor.validate_tool_call(
+            tool_name="Bash",
+            tool_input={"command": "sudo mkdir /tmp/test"},
+            working_directory=tmp_path,
+            user_id=123,
+        )
+        assert not valid
+        assert "dangerous command pattern" in error.lower()


### PR DESCRIPTION
Closes #31

## Summary

- Enable native SDK bash sandboxing (`SandboxSettings`) to enforce OS-level filesystem isolation for bash commands, restricted to the `cwd`/approved directory
- Add application-level directory boundary checking in `ToolMonitor` for filesystem-modifying bash commands (`mkdir`, `touch`, `cp`, `mv`, `rm`, etc.) as defense-in-depth
- Add `Bash` to the fail-fast critical tool list in the CLI fallback path
- Add `system_prompt` instructing Claude to use relative paths (catches excluded commands like `git`)

## Test plan

- [x] 16 new tests for `check_bash_directory_boundary()` covering: outside-dir blocked, inside-dir passes, relative paths pass, read-only commands pass, flags skipped, unparseable commands pass through
- [x] 3 new tests for SDK sandbox/system_prompt options on `ClaudeAgentOptions`
- [x] All 305 existing tests still pass
- [ ] Manual test: send "create a new project with an index.html" → created within approved dir
- [ ] Manual test: send "run `mkdir /tmp/test`" → blocked by sandbox with clear error