### PR TITLE
Fix: use name instead of tool_name on ToolUseBlock

### DIFF
--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -388,7 +388,7 @@ class ClaudeSDKManager:
                         if isinstance(block, ToolUseBlock):
                             tool_calls.append(
                                 {
-                                    "name": getattr(block, "tool_name", "unknown"),
+                                    "name": getattr(block, "name", "unknown"),
                                     "input": getattr(block, "tool_input", {}),
                                     "id": getattr(block, "id", None),
                                 }
@@ -456,7 +456,7 @@ class ClaudeSDKManager:
                         if isinstance(block, ToolUseBlock):
                             tools_used.append(
                                 {
-                                    "name": getattr(block, "tool_name", "unknown"),
+                                    "name": getattr(block, "name", "unknown"),
                                     "timestamp": current_time,
                                     "input": getattr(block, "tool_input", {}),
                                 }


### PR DESCRIPTION
## Summary
- `ToolUseBlock` in `claude-agent-sdk` uses `name`, not `tool_name`
- `getattr(block, "tool_name", "unknown")` always returns `"unknown"`, causing all tool calls to fail validation
- Fixes both occurrences on lines 391 and 459 of `src/claude/sdk_integration.py`

Fixes #37