### PR TITLE
chore: migrate pyproject.toml to PEP 621 format for Poetry 2.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2293,4 +2293,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "dd96981d06350b49a86f596e874c167ad142ea76602acf1128654046ea73b819"
+content-hash = "1446869f899302f1072be89d42a09eb6a8b07fb073ea5486d1991a88e4153652"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,16 @@
-[tool.poetry]
+[project]
 name = "claude-code-telegram"
 version = "1.2.0"
 description = "Telegram bot for remote Claude Code access with comprehensive configuration management"
-authors = ["Richard Atkinson <richardatk01@gmail.com>"]
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/richardatkinson/claude-code-telegram"
-repository = "https://github.com/richardatkinson/claude-code-telegram"
-documentation = "https://github.com/richardatkinson/claude-code-telegram/blob/main/docs/"
+license = "MIT"
+authors = [
+    {name = "Richard Atkinson", email = "richardatk01@gmail.com"},
+]
 keywords = ["telegram", "bot", "claude", "ai", "development", "remote", "coding"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
@@ -21,6 +19,22 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: System :: Shells",
 ]
+requires-python = ">=3.11"
+dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://github.com/richardatkinson/claude-code-telegram"
+Repository = "https://github.com/richardatkinson/claude-code-telegram"
+Documentation = "https://github.com/richardatkinson/claude-code-telegram/blob/main/docs/"
+
+[project.scripts]
+claude-telegram-bot = "src.main:run"
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
 packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
@@ -38,13 +52,6 @@ fastapi = "^0.115.0"
 uvicorn = {version = "^0.34.0", extras = ["standard"]}
 apscheduler = "^3.10"
 PyYAML = "^6.0.2"
-
-[tool.poetry.scripts]
-claude-telegram-bot = "src.main:run"
-
-[build-system]
-requires = ["poetry-core>=2.0.0"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"


### PR DESCRIPTION
Move project metadata (name, version, description, authors, license,
keywords, classifiers) from [tool.poetry] to [project]. Move URLs to
[project.urls] and console scripts to [project.scripts]. Add
dynamic = ["dependencies"] since Poetry manages deps via
[tool.poetry.dependencies]. Remove deprecated license classifier
(now handled by project.license). Resolves all poetry check warnings.

https://claude.ai/code/session_01TfVVuMToqHt1UcWq2sqa4k