### PR TITLE
Fix: prevent MessageParseError from killing SDK message stream

### DIFF
--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -29,6 +29,7 @@ from claude_agent_sdk import (
     UserMessage,
 )
 from claude_agent_sdk._errors import MessageParseError
+from claude_agent_sdk._internal.message_parser import parse_message
 
 from ..config.settings import Settings
 from .exceptions import (
@@ -208,15 +209,18 @@ class ClaudeSDKManager:
             async def _run_client() -> None:
                 async with ClaudeSDKClient(options) as client:
                     await client.query(prompt)
-                    response_iter = client.receive_response()
-                    while True:
+
+                    # Iterate over raw messages and parse them ourselves
+                    # so that MessageParseError (e.g. from rate_limit_event)
+                    # doesn't kill the underlying async generator. When
+                    # parse_message raises inside the SDK's receive_messages()
+                    # generator, Python terminates that generator permanently,
+                    # causing us to lose all subsequent messages including
+                    # the ResultMessage.
+                    async for raw_data in client._query.receive_messages():
                         try:
-                            message = await response_iter.__anext__()
-                        except StopAsyncIteration:
-                            break
+                            message = parse_message(raw_data)
                         except MessageParseError as e:
-                            # Skip unknown message types (e.g. rate_limit_event)
-                            # rather than failing the entire request
                             logger.debug(
                                 "Skipping unparseable message",
                                 error=str(e),
@@ -224,6 +228,9 @@ class ClaudeSDKManager:
                             continue
 
                         messages.append(message)
+
+                        if isinstance(message, ResultMessage):
+                            break
 
                         # Handle streaming callback
                         if stream_callback:


### PR DESCRIPTION
## Summary
- Fixed a critical bug where unknown SDK message types (e.g. `rate_limit_event`) caused `MessageParseError` to propagate through and **permanently terminate** the `receive_messages()` async generator
- This caused all subsequent messages to be lost, including `ResultMessage` — resulting in empty `session_id`, zero `cost`, and non-resumable sessions
- Added StreamEvent `session_id` fallback as defense-in-depth

## Root Cause
The SDK's `receive_messages()` generator calls `parse_message(data)` inside a `yield` expression. When `parse_message` raises `MessageParseError` for unknown types like `rate_limit_event`, the exception propagates out of the async generator. In Python, **this permanently terminates the generator** — even if the caller catches the exception and tries to continue iterating.

The previous code caught `MessageParseError` from the caller side and called `continue`, but this couldn't save the already-dead generator. The next `__anext__()` call received `StopAsyncIteration`, ending the loop before `ResultMessage` could arrive.

## Fix
Instead of using `client.receive_response()` (which wraps the fragile generator), iterate over `client._query.receive_messages()` directly (yields raw dicts) and call `parse_message()` ourselves with error handling **inside** the loop. Parse errors for unknown message types are now caught before they can kill the generator.

## Before / After
| | Before | After |
|---|---|---|
| `session_id` | `""` (empty) | `db7aa2b6-4dfa-4cfb-b268-d678ec082a91` |
| `cost` | `0.0` | `0.11` |
| Session resumable | No | Yes |
| `rate_limit_event` | Kills generator | Skipped gracefully |

## Test plan
- [x] 380 existing tests pass
- [x] 5 new tests for StreamEvent session_id fallback
- [x] Live-tested: bot receives messages, extracts session_id and cost, sessions persist in SQLite
- [x] Formatting checks pass (black, isort)