### PR TITLE
Add AskUserQuestion and PlanMode to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ CLAUDE_TIMEOUT_SECONDS=300
 CLAUDE_MAX_COST_PER_USER=10.0
 
 # Allowed Claude tools (comma-separated list)
-CLAUDE_ALLOWED_TOOLS=Read,Write,Edit,Bash,Glob,Grep,LS,Task,TaskOutput,MultiEdit,NotebookRead,NotebookEdit,WebFetch,TodoRead,TodoWrite,WebSearch,Skill
+CLAUDE_ALLOWED_TOOLS=Read,Write,Edit,Bash,Glob,Grep,LS,Task,TaskOutput,MultiEdit,NotebookRead,NotebookEdit,WebFetch,TodoRead,TodoWrite,WebSearch,Skill,AskUserQuestion,EnterPlanMode, ExitPlanMode
 
 # === RATE LIMITING ===
 # Number of requests allowed per window


### PR DESCRIPTION
Added `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode` to the `CLAUDE_ALLOWED_TOOLS` so anyone that starts with .env from .env.example will have them working in the chat.

I noticed that when I started with this, I just wanted to try it out with defaults, and as my flow is most of the time first planning and then execution, I ran into these three missing permissions pretty quickly. 

This will make the onboarding of new users hopefully even easier than it is now. 