### PR TITLE
Fix session resume failing with generic exit code 1

### DIFF
--- a/src/claude/facade.py
+++ b/src/claude/facade.py
@@ -150,12 +150,10 @@ class ClaudeIntegration:
                     stream_callback=stream_handler,
                 )
             except Exception as resume_error:
-                # If resume failed (e.g., session expired on Claude's side),
-                # retry as a fresh session
-                if (
-                    should_continue
-                    and "no conversation found" in str(resume_error).lower()
-                ):
+                # If resume failed (e.g., session expired/missing on Claude's side),
+                # retry as a fresh session.  The CLI returns a generic exit-code-1
+                # when the session is gone, so we catch *any* error during resume.
+                if should_continue:
                     logger.warning(
                         "Session resume failed, starting fresh session",
                         failed_session_id=claude_session_id,


### PR DESCRIPTION
When a session no longer exists on Claude's side, the CLI returns "No conversation found" via stderr and exits with code 1. However, the SDK hardcodes a generic error message instead of capturing the real stderr, so the bot never saw the actual reason.

Two fixes:
- Add stderr callback to ClaudeAgentOptions so real CLI errors are captured and logged instead of "Check stderr output for details"
- Widen the resume retry logic to catch any error during session resume (not just the specific "no conversation found" string that was never matched), automatically cleaning up the stale session and retrying with a fresh one