### PR TITLE
fix: image type detection stub and cost tracking

### DIFF
--- a/src/bot/features/image_handler.py
+++ b/src/bot/features/image_handler.py
@@ -72,12 +72,79 @@ class ImageHandler:
         )
 
     def _detect_image_type(self, image_bytes: bytes) -> str:
-        """Detect type of image"""
-        # Simple heuristic based on image characteristics
-        # In practice, could use ML model for better detection
+        """Detect type of image using format and dimension heuristics."""
+        fmt = self._detect_format(image_bytes)
+        width, height = self._get_dimensions(image_bytes, fmt)
 
-        # For now, return generic type
-        return "screenshot"
+        if width == 0 or height == 0:
+            return "generic"
+
+        aspect = width / height
+
+        # Very wide images are likely diagrams or flowcharts
+        if aspect > 2.5:
+            return "diagram"
+
+        # Very tall images are likely mobile screenshots or scrolling captures
+        if aspect < 0.4:
+            return "screenshot"
+
+        # Common desktop/mobile screenshot aspect ratios (16:9, 16:10, 9:16, etc.)
+        if 1.2 < aspect < 2.0 and width >= 800:
+            return "screenshot"
+
+        # Phone-portrait screenshots
+        if 0.4 <= aspect <= 0.65 and height >= 1000:
+            return "screenshot"
+
+        # Square-ish images with moderate resolution are often UI mockups
+        if 0.8 <= aspect <= 1.25 and width >= 400:
+            return "ui_mockup"
+
+        # Small images are likely icons or thumbnails
+        if width < 256 and height < 256:
+            return "generic"
+
+        return "generic"
+
+    @staticmethod
+    def _get_dimensions(image_bytes: bytes, fmt: str) -> tuple:
+        """Extract width and height from image bytes without PIL."""
+        try:
+            if fmt == "png" and len(image_bytes) >= 24:
+                # PNG: width at offset 16 (4 bytes BE), height at offset 20 (4 bytes BE)
+                w = int.from_bytes(image_bytes[16:20], "big")
+                h = int.from_bytes(image_bytes[20:24], "big")
+                return w, h
+            elif fmt == "jpeg" and len(image_bytes) > 2:
+                # JPEG: scan for SOF0/SOF2 markers (0xFF 0xC0 / 0xFF 0xC2)
+                i = 2
+                while i < len(image_bytes) - 9:
+                    if image_bytes[i] != 0xFF:
+                        i += 1
+                        continue
+                    marker = image_bytes[i + 1]
+                    if marker in (0xC0, 0xC2):
+                        h = int.from_bytes(image_bytes[i + 5 : i + 7], "big")
+                        w = int.from_bytes(image_bytes[i + 7 : i + 9], "big")
+                        return w, h
+                    # Skip to next marker
+                    length = int.from_bytes(image_bytes[i + 2 : i + 4], "big")
+                    i += 2 + length
+            elif fmt == "gif" and len(image_bytes) >= 10:
+                # GIF: width at offset 6 (2 bytes LE), height at offset 8 (2 bytes LE)
+                w = int.from_bytes(image_bytes[6:8], "little")
+                h = int.from_bytes(image_bytes[8:10], "little")
+                return w, h
+            elif fmt == "webp" and len(image_bytes) >= 30:
+                # WebP VP8: dimensions at offset 26-30
+                if image_bytes[12:16] == b"VP8 " and len(image_bytes) >= 30:
+                    w = int.from_bytes(image_bytes[26:28], "little") & 0x3FFF
+                    h = int.from_bytes(image_bytes[28:30], "little") & 0x3FFF
+                    return w, h
+        except Exception:
+            pass
+        return 0, 0
 
     def _detect_format(self, image_bytes: bytes) -> str:
         """Detect image format from magic bytes"""

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -702,7 +702,7 @@ class MessageOrchestrator:
         # Rate limit check
         rate_limiter = context.bot_data.get("rate_limiter")
         if rate_limiter:
-            allowed, limit_message = await rate_limiter.check_rate_limit(user_id, 0.001)
+            allowed, limit_message = await rate_limiter.check_rate_limit(user_id, 0.0)
             if not allowed:
                 await update.message.reply_text(f"⏱️ {limit_message}")
                 return
@@ -755,6 +755,10 @@ class MessageOrchestrator:
                 context.user_data["force_new_session"] = False
 
             context.user_data["claude_session_id"] = claude_response.session_id
+
+            # Track actual cost post-execution
+            if rate_limiter and claude_response.cost and claude_response.cost > 0:
+                await rate_limiter.check_rate_limit(user_id, claude_response.cost, 0)
 
             # Track directory changes
             from .handlers.message import _update_working_directory_from_claude_response

--- a/tests/unit/test_bot/test_image_handler.py
+++ b/tests/unit/test_bot/test_image_handler.py
@@ -1,0 +1,123 @@
+"""Tests for image type detection and dimension parsing."""
+
+import struct
+
+import pytest
+
+from src.bot.features.image_handler import ImageHandler
+from src.config.settings import Settings
+
+
+def _make_png(width: int, height: int) -> bytes:
+    """Build a minimal PNG header with the given dimensions."""
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">II", width, height) + b"\x08\x02\x00\x00\x00"
+    ihdr_len = struct.pack(">I", len(ihdr_data))
+    return sig + ihdr_len + b"IHDR" + ihdr_data
+
+
+def _make_gif(width: int, height: int) -> bytes:
+    """Build a minimal GIF header with the given dimensions."""
+    header = b"GIF89a"
+    dims = struct.pack("<HH", width, height)
+    return header + dims + b"\x00" * 10
+
+
+def _make_jpeg_sof(width: int, height: int) -> bytes:
+    """Build a minimal JPEG with an SOF0 marker containing dimensions."""
+    data = b"\xff\xd8"
+    sof_length = struct.pack(">H", 8)
+    precision = b"\x08"
+    h_bytes = struct.pack(">H", height)
+    w_bytes = struct.pack(">H", width)
+    data += b"\xff\xc0" + sof_length + precision + h_bytes + w_bytes
+    return data
+
+
+class TestImageDimensionParsing:
+    """Test _get_dimensions for each supported format."""
+
+    def test_png_dimensions(self):
+        data = _make_png(1920, 1080)
+        w, h = ImageHandler._get_dimensions(data, "png")
+        assert (w, h) == (1920, 1080)
+
+    def test_gif_dimensions(self):
+        data = _make_gif(800, 600)
+        w, h = ImageHandler._get_dimensions(data, "gif")
+        assert (w, h) == (800, 600)
+
+    def test_jpeg_dimensions(self):
+        data = _make_jpeg_sof(1440, 900)
+        w, h = ImageHandler._get_dimensions(data, "jpeg")
+        assert (w, h) == (1440, 900)
+
+    def test_unknown_format_returns_zero(self):
+        w, h = ImageHandler._get_dimensions(b"\x00" * 50, "bmp")
+        assert (w, h) == (0, 0)
+
+    def test_truncated_png_returns_zero(self):
+        w, h = ImageHandler._get_dimensions(b"\x89PNG\r\n\x1a\n" + b"\x00" * 5, "png")
+        assert (w, h) == (0, 0)
+
+    def test_empty_bytes_returns_zero(self):
+        w, h = ImageHandler._get_dimensions(b"", "png")
+        assert (w, h) == (0, 0)
+
+
+class TestImageTypeDetection:
+    """Test _detect_image_type heuristic classifications."""
+
+    @pytest.fixture
+    def handler(self, tmp_path):
+        config = Settings(
+            telegram_bot_token="fake:token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+        )
+        return ImageHandler(config)
+
+    def test_desktop_screenshot_detected(self, handler):
+        """1920x1080 (16:9, width >= 800) should be screenshot."""
+        data = _make_png(1920, 1080)
+        assert handler._detect_image_type(data) == "screenshot"
+
+    def test_wide_diagram_detected(self, handler):
+        """Very wide image (aspect > 2.5) should be diagram."""
+        data = _make_png(3000, 400)
+        assert handler._detect_image_type(data) == "diagram"
+
+    def test_tall_mobile_screenshot(self, handler):
+        """Very tall image (aspect < 0.4) should be screenshot."""
+        data = _make_png(400, 1200)
+        assert handler._detect_image_type(data) == "screenshot"
+
+    def test_phone_portrait_screenshot(self, handler):
+        """Phone-portrait dimensions should be screenshot."""
+        data = _make_png(750, 1334)
+        assert handler._detect_image_type(data) == "screenshot"
+
+    def test_square_moderate_is_ui_mockup(self, handler):
+        """Square-ish moderate resolution should be ui_mockup."""
+        data = _make_png(500, 500)
+        assert handler._detect_image_type(data) == "ui_mockup"
+
+    def test_small_image_is_generic(self, handler):
+        """Small images (< 256x256) should be generic."""
+        data = _make_png(100, 100)
+        assert handler._detect_image_type(data) == "generic"
+
+    def test_unrecognised_format_is_generic(self, handler):
+        """Unknown format returns generic."""
+        data = b"\x00" * 100
+        assert handler._detect_image_type(data) == "generic"
+
+    def test_gif_dimensions_parsed(self, handler):
+        """GIF with desktop dimensions should be screenshot."""
+        data = _make_gif(1920, 1080)
+        assert handler._detect_image_type(data) == "screenshot"
+
+    def test_jpeg_dimensions_parsed(self, handler):
+        """JPEG with desktop dimensions should be screenshot."""
+        data = _make_jpeg_sof(1440, 900)
+        assert handler._detect_image_type(data) == "screenshot"


### PR DESCRIPTION
## Summary

- **Image detection**: The `_detect_image_type` method was a stub that always returned `"screenshot"` regardless of input. This replaces it with dimension-based heuristics that parse PNG/JPEG/GIF/WebP binary headers to extract width/height, then classify based on aspect ratio and resolution (screenshots, diagrams, UI mockups, generic).
- **Cost tracking**: The rate limiter pre-check used a hardcoded `0.001` cost, meaning every message was charged a phantom cost before Claude even ran. Changed to `0.0` so the pre-check only enforces request rate limiting. Added post-execution cost tracking that records the actual cost from `claude_response.cost`.
- **Tests**: Added unit tests for `_get_dimensions` (PNG, GIF, JPEG, truncated, empty) and `_detect_image_type` (desktop screenshot, diagram, mobile screenshot, UI mockup, generic, multi-format).

Split from #39 per maintainer request — this PR contains only the image detection and cost tracking fixes.

## Test plan

- [ ] Verify `_get_dimensions` correctly parses PNG, JPEG, GIF headers
- [ ] Verify `_detect_image_type` returns correct types for different aspect ratios/resolutions  
- [ ] Verify rate limiter pre-check no longer charges phantom 0.001 cost
- [ ] Verify actual cost is tracked after Claude response
- [ ] Run `pytest tests/unit/test_bot/test_image_handler.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)