### PR TITLE
fix: replace in-memory storage with SQLite persistence

### DIFF
--- a/src/security/audit.py
+++ b/src/security/audit.py
@@ -7,12 +7,17 @@ Features:
 - Security violations
 """
 
+from __future__ import annotations
+
 import json
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import structlog
+
+if TYPE_CHECKING:
+    from src.storage.database import DatabaseManager
 
 # from src.exceptions import SecurityError  # Future use
 
@@ -125,6 +130,110 @@ class InMemoryAuditStorage(AuditStorage):
         self, user_id: Optional[int] = None, limit: int = 100
     ) -> List[AuditEvent]:
         """Get security violations."""
+        return await self.get_events(
+            user_id=user_id, event_type="security_violation", limit=limit
+        )
+
+
+
+class SQLiteAuditStorage(AuditStorage):
+    """SQLite-backed audit storage for production use."""
+
+    def __init__(self, db_manager: DatabaseManager) -> None:
+        self.db = db_manager
+
+    async def store_event(self, event: AuditEvent) -> None:
+        """Store event in SQLite."""
+        async with self.db.get_connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO audit_log
+                (user_id, event_type, event_data, success, timestamp, ip_address)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.user_id,
+                    event.event_type,
+                    json.dumps(event.details),
+                    event.success,
+                    event.timestamp.isoformat(),
+                    event.ip_address,
+                ),
+            )
+            await conn.commit()
+
+        # Log high-risk events immediately
+        if event.risk_level in ["high", "critical"]:
+            logger.warning(
+                "High-risk security event",
+                event_type=event.event_type,
+                user_id=event.user_id,
+                risk_level=event.risk_level,
+                details=event.details,
+            )
+
+    async def get_events(
+        self,
+        user_id: int | None = None,
+        event_type: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        limit: int = 100,
+    ) -> List[AuditEvent]:
+        """Get filtered events from SQLite."""
+        conditions: list[str] = []
+        params: list[object] = []
+
+        if user_id is not None:
+            conditions.append("user_id = ?")
+            params.append(user_id)
+        if event_type is not None:
+            conditions.append("event_type = ?")
+            params.append(event_type)
+        if start_time is not None:
+            conditions.append("timestamp >= ?")
+            params.append(start_time.isoformat())
+        if end_time is not None:
+            conditions.append("timestamp <= ?")
+            params.append(end_time.isoformat())
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        query = (
+            f"SELECT user_id, event_type, event_data, success, timestamp, ip_address "
+            f"FROM audit_log {where} ORDER BY timestamp DESC LIMIT ?"
+        )
+        params.append(limit)
+
+        async with self.db.get_connection() as conn:
+            cursor = await conn.execute(query, params)
+            rows = await cursor.fetchall()
+
+        events: list[AuditEvent] = []
+        for row in rows:
+            details: Dict[str, Any] = {}
+            if row["event_data"]:
+                try:
+                    details = json.loads(row["event_data"])
+                except (json.JSONDecodeError, TypeError):
+                    details = {"raw": str(row["event_data"])}
+
+            events.append(
+                AuditEvent(
+                    timestamp=datetime.fromisoformat(str(row["timestamp"])),
+                    user_id=row["user_id"],
+                    event_type=row["event_type"],
+                    success=bool(row["success"]),
+                    details=details,
+                    ip_address=row["ip_address"],
+                    risk_level=details.get("risk_level", "low"),
+                )
+            )
+        return events
+
+    async def get_security_violations(
+        self, user_id: int | None = None, limit: int = 100
+    ) -> List[AuditEvent]:
+        """Get security violations from SQLite."""
         return await self.get_events(
             user_id=user_id, event_type="security_violation", limit=limit
         )

--- a/src/security/auth.py
+++ b/src/security/auth.py
@@ -7,14 +7,19 @@ Features:
 - Audit logging
 """
 
+from __future__ import annotations
+
 import hashlib
 import secrets
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import structlog
+
+if TYPE_CHECKING:
+    from src.storage.database import DatabaseManager
 
 from src.exceptions import SecurityError
 
@@ -137,6 +142,76 @@ class InMemoryTokenStorage(TokenStorage):
     async def revoke_token(self, user_id: int) -> None:
         """Remove token from memory."""
         self._tokens.pop(user_id, None)
+
+
+
+class SQLiteTokenStorage(TokenStorage):
+    """SQLite-backed token storage for production use."""
+
+    def __init__(self, db_manager: DatabaseManager) -> None:
+        self.db = db_manager
+
+    async def store_token(
+        self, user_id: int, token_hash: str, expires_at: datetime
+    ) -> None:
+        """Store token hash in SQLite."""
+        async with self.db.get_connection() as conn:
+            # Deactivate existing tokens for this user
+            await conn.execute(
+                "UPDATE user_tokens SET is_active = FALSE WHERE user_id = ?",
+                (user_id,),
+            )
+            # Insert new token
+            await conn.execute(
+                """
+                INSERT INTO user_tokens (user_id, token_hash, expires_at, is_active)
+                VALUES (?, ?, ?, TRUE)
+                """,
+                (user_id, token_hash, expires_at.isoformat()),
+            )
+            await conn.commit()
+
+    async def get_user_token(self, user_id: int) -> dict[str, Any] | None:
+        """Get active token data from SQLite."""
+        async with self.db.get_connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT token_hash, created_at, expires_at
+                FROM user_tokens
+                WHERE user_id = ? AND is_active = TRUE
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                (user_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+
+            expires_at = datetime.fromisoformat(str(row["expires_at"]))
+            if expires_at <= datetime.now(UTC):
+                # Token expired — deactivate it
+                await conn.execute(
+                    "UPDATE user_tokens SET is_active = FALSE "
+                    "WHERE user_id = ? AND is_active = TRUE",
+                    (user_id,),
+                )
+                await conn.commit()
+                return None
+
+            return {
+                "hash": row["token_hash"],
+                "created_at": datetime.fromisoformat(str(row["created_at"])),
+                "expires_at": expires_at,
+            }
+
+    async def revoke_token(self, user_id: int) -> None:
+        """Deactivate all tokens for user."""
+        async with self.db.get_connection() as conn:
+            await conn.execute(
+                "UPDATE user_tokens SET is_active = FALSE WHERE user_id = ?",
+                (user_id,),
+            )
+            await conn.commit()
 
 
 class TokenAuthProvider(AuthProvider):

--- a/tests/unit/test_security/test_sqlite_storage.py
+++ b/tests/unit/test_security/test_sqlite_storage.py
@@ -1,0 +1,213 @@
+"""Tests for SQLite-backed audit and token storage."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.security.audit import AuditEvent, SQLiteAuditStorage
+from src.security.auth import SQLiteTokenStorage
+from src.storage.database import DatabaseManager
+
+
+@pytest.fixture
+async def db_manager(tmp_path):
+    """Create an in-memory DatabaseManager with schema initialised."""
+    db_url = str(tmp_path / "test.db")
+    manager = DatabaseManager(db_url)
+    await manager.initialize()
+    return manager
+
+
+class TestSQLiteAuditStorage:
+    """Test SQLite-backed audit storage."""
+
+    @pytest.fixture
+    async def storage(self, db_manager):
+        return SQLiteAuditStorage(db_manager)
+
+    async def test_store_and_retrieve_event(self, storage):
+        """Test round-trip store then retrieve."""
+        event = AuditEvent(
+            timestamp=datetime.now(UTC),
+            user_id=123,
+            event_type="test_event",
+            success=True,
+            details={"action": "test"},
+            risk_level="low",
+        )
+        await storage.store_event(event)
+
+        events = await storage.get_events()
+        assert len(events) == 1
+        assert events[0].user_id == 123
+        assert events[0].event_type == "test_event"
+        assert events[0].success is True
+        assert events[0].details["action"] == "test"
+
+    async def test_filter_by_user_id(self, storage):
+        """Test filtering events by user_id."""
+        for uid in [100, 200, 100]:
+            await storage.store_event(
+                AuditEvent(
+                    timestamp=datetime.now(UTC),
+                    user_id=uid,
+                    event_type="cmd",
+                    success=True,
+                    details={},
+                )
+            )
+
+        events = await storage.get_events(user_id=100)
+        assert len(events) == 2
+        assert all(e.user_id == 100 for e in events)
+
+    async def test_filter_by_event_type(self, storage):
+        """Test filtering events by event_type."""
+        for etype in ["auth", "command", "auth"]:
+            await storage.store_event(
+                AuditEvent(
+                    timestamp=datetime.now(UTC),
+                    user_id=1,
+                    event_type=etype,
+                    success=True,
+                    details={},
+                )
+            )
+
+        events = await storage.get_events(event_type="auth")
+        assert len(events) == 2
+
+    async def test_filter_by_time_range(self, storage):
+        """Test filtering by start_time."""
+        old = datetime.now(UTC) - timedelta(hours=2)
+        now = datetime.now(UTC)
+
+        await storage.store_event(
+            AuditEvent(
+                timestamp=old, user_id=1, event_type="old", success=True, details={}
+            )
+        )
+        await storage.store_event(
+            AuditEvent(
+                timestamp=now, user_id=1, event_type="new", success=True, details={}
+            )
+        )
+
+        events = await storage.get_events(start_time=now - timedelta(minutes=30))
+        assert len(events) == 1
+        assert events[0].event_type == "new"
+
+    async def test_limit(self, storage):
+        """Test that limit is respected."""
+        for i in range(5):
+            await storage.store_event(
+                AuditEvent(
+                    timestamp=datetime.now(UTC),
+                    user_id=i,
+                    event_type="t",
+                    success=True,
+                    details={},
+                )
+            )
+
+        events = await storage.get_events(limit=3)
+        assert len(events) == 3
+
+    async def test_get_security_violations(self, storage):
+        """Test security violations filter."""
+        await storage.store_event(
+            AuditEvent(
+                timestamp=datetime.now(UTC),
+                user_id=1,
+                event_type="command",
+                success=True,
+                details={},
+            )
+        )
+        await storage.store_event(
+            AuditEvent(
+                timestamp=datetime.now(UTC),
+                user_id=1,
+                event_type="security_violation",
+                success=False,
+                details={"violation_type": "path_traversal"},
+            )
+        )
+
+        violations = await storage.get_security_violations()
+        assert len(violations) == 1
+        assert violations[0].event_type == "security_violation"
+
+    async def test_malformed_event_data_handled(self, storage):
+        """Test that malformed JSON in event_data doesn't crash."""
+        # Store a valid event first
+        await storage.store_event(
+            AuditEvent(
+                timestamp=datetime.now(UTC),
+                user_id=1,
+                event_type="test",
+                success=True,
+                details={"key": "value"},
+            )
+        )
+
+        # Manually corrupt the event_data in the DB
+        async with storage.db.get_connection() as conn:
+            await conn.execute(
+                "UPDATE audit_log SET event_data = 'not-json' WHERE user_id = 1"
+            )
+            await conn.commit()
+
+        events = await storage.get_events()
+        assert len(events) == 1
+        assert "raw" in events[0].details
+
+
+class TestSQLiteTokenStorage:
+    """Test SQLite-backed token storage."""
+
+    @pytest.fixture
+    async def storage(self, db_manager):
+        return SQLiteTokenStorage(db_manager)
+
+    async def test_store_and_retrieve_token(self, storage):
+        """Test storing and retrieving a token."""
+        expires = datetime.now(UTC) + timedelta(days=1)
+        await storage.store_token(123, "hash_abc", expires)
+
+        token = await storage.get_user_token(123)
+        assert token is not None
+        assert token["hash"] == "hash_abc"
+
+    async def test_expired_token_returns_none(self, storage):
+        """Test that expired tokens are not returned."""
+        expires = datetime.now(UTC) - timedelta(days=1)
+        await storage.store_token(123, "hash_old", expires)
+
+        token = await storage.get_user_token(123)
+        assert token is None
+
+    async def test_new_token_deactivates_old(self, storage):
+        """Test that storing a new token deactivates previous ones."""
+        expires = datetime.now(UTC) + timedelta(days=1)
+        await storage.store_token(123, "hash_first", expires)
+        await storage.store_token(123, "hash_second", expires)
+
+        token = await storage.get_user_token(123)
+        assert token is not None
+        assert token["hash"] == "hash_second"
+
+    async def test_revoke_token(self, storage):
+        """Test token revocation."""
+        expires = datetime.now(UTC) + timedelta(days=1)
+        await storage.store_token(123, "hash_abc", expires)
+
+        await storage.revoke_token(123)
+
+        token = await storage.get_user_token(123)
+        assert token is None
+
+    async def test_get_nonexistent_user_token(self, storage):
+        """Test getting token for user with no tokens."""
+        token = await storage.get_user_token(999)
+        assert token is None


### PR DESCRIPTION
## Summary

- **Audit storage**: Added `SQLiteAuditStorage` that implements the `AuditStorage` interface using the existing `audit_log` DB table. Supports filtered queries by user_id, event_type, time range, and limit. Handles malformed JSON in `event_data` gracefully.
- **Token storage**: Added `SQLiteTokenStorage` that implements the `TokenStorage` interface using the existing `user_tokens` DB table. Automatically deactivates previous tokens when storing new ones, and cleans up expired tokens on retrieval.
- **main.py wiring**: `InMemoryAuditStorage()` replaced with `SQLiteAuditStorage(storage.db_manager)` and `InMemoryTokenStorage()` replaced with `SQLiteTokenStorage(storage.db_manager)`. Both TODO comments resolved.
- **In-memory classes preserved**: `InMemoryAuditStorage` and `InMemoryTokenStorage` remain available for development and testing.
- **Tests**: Added unit tests for both SQLite storage classes covering store/retrieve, filtering, expiry, revocation, and edge cases.

This fixes the issue where all audit logs and authentication tokens were lost on every bot restart.

Split from #39 per maintainer request — this PR contains only the storage persistence fixes.

## Test plan

- [ ] Verify `SQLiteAuditStorage` stores and retrieves events correctly
- [ ] Verify event filtering by user_id, event_type, time range works
- [ ] Verify `SQLiteTokenStorage` stores, retrieves, and revokes tokens
- [ ] Verify expired tokens are cleaned up automatically
- [ ] Verify new token deactivates previous tokens for same user
- [ ] Run `pytest tests/unit/test_security/test_sqlite_storage.py`
- [ ] Verify bot starts correctly with SQLite storage (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)