### PR TITLE
Add new MCP server + send_image_to_user tool for outbound image delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ data/
 sessions/
 backups/
 uploads/
+config/mcp.json

--- a/config/mcp.example.json
+++ b/config/mcp.example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "telegram": {
+      "command": "python",
+      "args": ["src/mcp/telegram_server.py"]
+    }
+  }
+}

--- a/src/bot/utils/image_extractor.py
+++ b/src/bot/utils/image_extractor.py
@@ -1,9 +1,13 @@
-"""Extract image file paths from Claude responses and prepare them for Telegram delivery."""
+"""Validate image file paths and prepare them for Telegram delivery.
 
-import re
+Used by the MCP ``send_image_to_user`` tool intercept — the stream callback
+validates each path via :func:`validate_image_path` and collects
+:class:`ImageAttachment` objects for later Telegram delivery.
+"""
+
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 import structlog
 
@@ -28,43 +32,6 @@ MAX_IMAGES_PER_RESPONSE = 10
 MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024  # 50 MB
 PHOTO_SIZE_LIMIT = 10 * 1024 * 1024  # 10 MB — Telegram photo API limit
 
-# Regex patterns to find image file paths in text.
-# Order matters: more specific patterns first to avoid partial matches.
-_IMAGE_EXT_PATTERN = r"\.(?:png|jpe?g|gif|webp|bmp|svg)"
-
-_PATH_PATTERNS = [
-    # Markdown image syntax: ![alt](path)
-    re.compile(
-        rf"!\[[^\]]*\]\(([^)]+{_IMAGE_EXT_PATTERN})\)",
-        re.IGNORECASE,
-    ),
-    # Backtick-wrapped path: `path/to/image.png`
-    re.compile(
-        rf"`([^`\n]+{_IMAGE_EXT_PATTERN})`",
-        re.IGNORECASE,
-    ),
-    # Double-quoted path: "path/to/image.png"
-    re.compile(
-        rf'"([^"\n]+{_IMAGE_EXT_PATTERN})"',
-        re.IGNORECASE,
-    ),
-    # Single-quoted path: 'path/to/image.png'
-    re.compile(
-        rf"'([^'\n]+{_IMAGE_EXT_PATTERN})'",
-        re.IGNORECASE,
-    ),
-    # Bare absolute path: /home/user/image.png (must start with /)
-    re.compile(
-        rf"(?:^|[\s])(/[^\s,;\"'`\])<>]+{_IMAGE_EXT_PATTERN})(?=[\s,;\"'`\])<>]|$)",
-        re.IGNORECASE | re.MULTILINE,
-    ),
-    # Bare relative path: ./dir/image.png or dir/image.png (must contain /)
-    re.compile(
-        rf"(?:^|[\s])(\.?\.?/[^\s,;\"'`\])<>]+{_IMAGE_EXT_PATTERN})(?=[\s,;\"'`\])<>]|$)",
-        re.IGNORECASE | re.MULTILINE,
-    ),
-]
-
 
 @dataclass
 class ImageAttachment:
@@ -75,25 +42,21 @@ class ImageAttachment:
     original_reference: str
 
 
-def _validate_and_add(
-    raw_path: str,
-    working_directory: Path,
+def validate_image_path(
+    file_path: str,
     approved_directory: Path,
-    seen_paths: set[Path],
-    results: List[ImageAttachment],
-) -> bool:
-    """Validate a single candidate path and append to results if valid.
+    caption: str = "",
+) -> Optional[ImageAttachment]:
+    """Validate a single image path from an MCP ``send_image_to_user`` call.
 
-    Returns True if the cap has been reached.
+    Returns an :class:`ImageAttachment` if the path is a valid, existing image
+    inside *approved_directory*, or ``None`` otherwise.
     """
     try:
-        path = Path(raw_path)
-
-        # Resolve relative paths against working directory
+        path = Path(file_path)
         if not path.is_absolute():
-            path = working_directory / path
+            return None
 
-        # Resolve symlinks for security check
         resolved = path.resolve()
 
         # Security: must be within approved directory
@@ -101,142 +64,33 @@ def _validate_and_add(
             resolved.relative_to(approved_directory.resolve())
         except ValueError:
             logger.debug(
-                "Image path outside approved directory",
+                "MCP image path outside approved directory",
                 path=str(resolved),
                 approved=str(approved_directory),
             )
-            return False
+            return None
 
-        # Skip duplicates
-        if resolved in seen_paths:
-            return False
-
-        # Check file exists
         if not resolved.is_file():
-            return False
+            return None
 
-        # Check file size
         file_size = resolved.stat().st_size
         if file_size > MAX_FILE_SIZE_BYTES:
-            logger.debug(
-                "Image file too large",
-                path=str(resolved),
-                size=file_size,
-            )
-            return False
+            logger.debug("MCP image file too large", path=str(resolved), size=file_size)
+            return None
 
-        # Determine MIME type
         ext = resolved.suffix.lower()
         mime_type = IMAGE_EXTENSIONS.get(ext)
         if not mime_type:
-            return False
+            return None
 
-        seen_paths.add(resolved)
-        results.append(
-            ImageAttachment(
-                path=resolved,
-                mime_type=mime_type,
-                original_reference=raw_path,
-            )
+        return ImageAttachment(
+            path=resolved,
+            mime_type=mime_type,
+            original_reference=caption or file_path,
         )
-
-        return len(results) >= MAX_IMAGES_PER_RESPONSE
-
     except (OSError, ValueError) as e:
-        logger.debug(
-            "Failed to process image path",
-            raw_path=raw_path,
-            error=str(e),
-        )
-        return False
-
-
-def _extract_image_paths_from_tools(
-    tools_used: List[Dict[str, Any]],
-) -> List[str]:
-    """Extract candidate image file paths from Claude's tool calls.
-
-    Looks at file_path in Read/Write/Edit inputs and command output in Bash.
-    """
-    candidates: List[str] = []
-    image_ext_set = set(IMAGE_EXTENSIONS.keys())
-
-    for tool in tools_used:
-        name = tool.get("name", "")
-        tool_input = tool.get("input", {})
-        if not isinstance(tool_input, dict):
-            continue
-
-        # Read, Write, Edit — check file_path
-        if name in ("Read", "Write", "Edit", "MultiEdit"):
-            file_path = tool_input.get("file_path", "")
-            if file_path and isinstance(file_path, str):
-                ext = Path(file_path).suffix.lower()
-                if ext in image_ext_set:
-                    candidates.append(file_path)
-
-        # Bash — scan command for output redirection to image files
-        elif name == "Bash":
-            cmd = tool_input.get("command", "")
-            if isinstance(cmd, str):
-                # Look for image paths in the command string
-                for ext in image_ext_set:
-                    if ext in cmd.lower():
-                        # Extract paths from the command
-                        for token in cmd.split():
-                            token = token.strip("\"';(){}[]")
-                            if Path(token).suffix.lower() in image_ext_set:
-                                candidates.append(token)
-
-    return candidates
-
-
-def extract_images_from_response(
-    text: str,
-    working_directory: Path,
-    approved_directory: Path,
-    tools_used: Optional[List[Dict[str, Any]]] = None,
-) -> List[ImageAttachment]:
-    """Scan response text and tool calls for image file paths.
-
-    Only returns images that:
-    - Have a recognised image extension
-    - Exist on disk
-    - Resolve to within ``approved_directory`` (follows symlinks)
-    - Are ≤ 50 MB
-    """
-    seen_paths: set[Path] = set()
-    results: List[ImageAttachment] = []
-
-    # 1) Scan response text for image paths
-    if text:
-        for pattern in _PATH_PATTERNS:
-            for match in pattern.finditer(text):
-                raw_path = match.group(1).strip()
-                if not raw_path:
-                    continue
-                if _validate_and_add(
-                    raw_path,
-                    working_directory,
-                    approved_directory,
-                    seen_paths,
-                    results,
-                ):
-                    return results
-
-    # 2) Scan tool calls for image file paths (Read, Write, Bash, etc.)
-    if tools_used:
-        for raw_path in _extract_image_paths_from_tools(tools_used):
-            if _validate_and_add(
-                raw_path,
-                working_directory,
-                approved_directory,
-                seen_paths,
-                results,
-            ):
-                return results
-
-    return results
+        logger.debug("MCP image path validation failed", path=file_path, error=str(e))
+        return None
 
 
 def should_send_as_photo(path: Path) -> bool:

--- a/src/events/types.py
+++ b/src/events/types.py
@@ -52,4 +52,3 @@ class AgentResponseEvent(Event):
     reply_to_message_id: Optional[int] = None
     source: str = "agent"
     originating_event_id: Optional[str] = None
-    image_paths: List[str] = field(default_factory=list)

--- a/src/mcp/telegram_server.py
+++ b/src/mcp/telegram_server.py
@@ -1,0 +1,47 @@
+"""MCP server exposing Telegram-specific tools to Claude.
+
+Runs as a stdio transport server. The ``send_image_to_user`` tool validates
+file existence and extension, then returns a success string. Actual Telegram
+delivery is handled by the bot's stream callback which intercepts the tool
+call.
+"""
+
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
+
+mcp = FastMCP("telegram")
+
+
+@mcp.tool()
+async def send_image_to_user(file_path: str, caption: str = "") -> str:
+    """Send an image file to the Telegram user.
+
+    Args:
+        file_path: Absolute path to the image file.
+        caption: Optional caption to display with the image.
+
+    Returns:
+        Confirmation string when the image is queued for delivery.
+    """
+    path = Path(file_path)
+
+    if not path.is_absolute():
+        return f"Error: path must be absolute, got '{file_path}'"
+
+    if path.suffix.lower() not in IMAGE_EXTENSIONS:
+        return (
+            f"Error: unsupported image extension '{path.suffix}'. "
+            f"Supported: {', '.join(sorted(IMAGE_EXTENSIONS))}"
+        )
+
+    if not path.is_file():
+        return f"Error: file not found: {file_path}"
+
+    return f"Image queued for delivery: {path.name}"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/unit/test_bot/test_image_extractor.py
+++ b/tests/unit/test_bot/test_image_extractor.py
@@ -1,4 +1,4 @@
-"""Tests for image extraction from Claude responses."""
+"""Tests for image validation and Telegram delivery helpers."""
 
 from pathlib import Path
 from unittest.mock import patch
@@ -8,12 +8,11 @@ import pytest
 from src.bot.utils.image_extractor import (
     IMAGE_EXTENSIONS,
     MAX_FILE_SIZE_BYTES,
-    MAX_IMAGES_PER_RESPONSE,
     PHOTO_SIZE_LIMIT,
     TELEGRAM_PHOTO_EXTENSIONS,
     ImageAttachment,
-    extract_images_from_response,
     should_send_as_photo,
+    validate_image_path,
 )
 
 
@@ -22,7 +21,6 @@ def work_dir(tmp_path: Path) -> Path:
     """Create a working directory with some image files."""
     img_dir = tmp_path / "project"
     img_dir.mkdir()
-    # Create some image files
     for name in [
         "chart.png",
         "photo.jpg",
@@ -33,10 +31,6 @@ def work_dir(tmp_path: Path) -> Path:
         "shot.jpeg",
     ]:
         (img_dir / name).write_bytes(b"\x00" * 100)
-    # Create a subdirectory with images
-    sub = img_dir / "output"
-    sub.mkdir()
-    (sub / "result.png").write_bytes(b"\x00" * 100)
     return img_dir
 
 
@@ -44,148 +38,6 @@ def work_dir(tmp_path: Path) -> Path:
 def approved_dir(tmp_path: Path) -> Path:
     """The approved directory is tmp_path itself."""
     return tmp_path
-
-
-# --- Path detection patterns ---
-
-
-class TestBacktickPaths:
-    def test_backtick_wrapped_absolute(self, work_dir: Path, approved_dir: Path):
-        text = f"I saved the chart to `{work_dir}/chart.png`."
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-        assert result[0].path == (work_dir / "chart.png").resolve()
-
-    def test_backtick_wrapped_relative(self, work_dir: Path, approved_dir: Path):
-        text = "The output is at `output/result.png`."
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-        assert result[0].path == (work_dir / "output" / "result.png").resolve()
-
-
-class TestQuotedPaths:
-    def test_double_quoted(self, work_dir: Path, approved_dir: Path):
-        text = f'Saved to "{work_dir}/photo.jpg" successfully.'
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-        assert result[0].mime_type == "image/jpeg"
-
-    def test_single_quoted(self, work_dir: Path, approved_dir: Path):
-        text = f"Saved to '{work_dir}/diagram.svg' successfully."
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-        assert result[0].mime_type == "image/svg+xml"
-
-
-class TestMarkdownImageSyntax:
-    def test_markdown_image(self, work_dir: Path, approved_dir: Path):
-        text = f"![Chart](/{work_dir}/chart.png)"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-    def test_markdown_image_with_alt_text(self, work_dir: Path, approved_dir: Path):
-        text = f"![My fancy chart](/{work_dir}/chart.png)"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-
-class TestBarePaths:
-    def test_bare_absolute_path(self, work_dir: Path, approved_dir: Path):
-        text = f"The file is at {work_dir}/chart.png and it looks great."
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-    def test_bare_relative_path_with_dot_slash(
-        self, work_dir: Path, approved_dir: Path
-    ):
-        text = "Created ./chart.png in the current directory."
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-
-class TestMultipleImages:
-    def test_multiple_images_in_response(self, work_dir: Path, approved_dir: Path):
-        text = (
-            f"Created `{work_dir}/chart.png` and `{work_dir}/photo.jpg`.\n"
-            f"Also saved `{work_dir}/diagram.svg`."
-        )
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 3
-
-
-# --- Security tests ---
-
-
-class TestSecurityValidation:
-    def test_reject_path_outside_approved_dir(self, work_dir: Path, tmp_path: Path):
-        """Paths outside approved_directory must be rejected."""
-        outside = tmp_path / "outside"
-        outside.mkdir()
-        img = outside / "evil.png"
-        img.write_bytes(b"\x00" * 100)
-
-        text = f"`{img}`"
-        # approved_dir is work_dir (a subdir of tmp_path), not tmp_path
-        result = extract_images_from_response(text, work_dir, work_dir)
-        assert len(result) == 0
-
-    def test_reject_symlink_escaping_boundary(self, work_dir: Path, tmp_path: Path):
-        """Symlinks that resolve outside approved_directory must be rejected."""
-        outside = tmp_path / "secret"
-        outside.mkdir()
-        secret_img = outside / "secret.png"
-        secret_img.write_bytes(b"\x00" * 100)
-
-        # Create symlink inside work_dir pointing outside
-        link = work_dir / "link.png"
-        link.symlink_to(secret_img)
-
-        text = f"`{link}`"
-        result = extract_images_from_response(text, work_dir, work_dir)
-        assert len(result) == 0
-
-    def test_path_traversal_rejected(self, work_dir: Path, approved_dir: Path):
-        """Paths with .. that escape the boundary must be rejected."""
-        # Create file outside
-        outside = approved_dir.parent / "outside_img.png"
-        outside.write_bytes(b"\x00" * 100)
-
-        text = f"`{work_dir}/../../outside_img.png`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 0
-
-
-# --- File validation ---
-
-
-class TestFileValidation:
-    def test_skip_nonexistent_files(self, work_dir: Path, approved_dir: Path):
-        text = f"`{work_dir}/nonexistent.png`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 0
-
-    def test_skip_large_files(self, work_dir: Path, approved_dir: Path):
-        """Files over 50 MB should be skipped."""
-        big = work_dir / "huge.png"
-        big.write_bytes(b"\x00" * 100)
-
-        text = f"`{big}`"
-        # Mock stat to report huge size
-        with patch.object(Path, "stat") as mock_stat:
-            mock_stat.return_value.st_size = MAX_FILE_SIZE_BYTES + 1
-            # Also need is_file to return True
-            with patch.object(Path, "is_file", return_value=True):
-                result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 0
-
-    def test_skip_non_image_extensions(self, work_dir: Path, approved_dir: Path):
-        """Only recognised image extensions should be extracted."""
-        txt_file = work_dir / "notes.txt"
-        txt_file.write_text("hello")
-
-        text = f"`{txt_file}`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 0
 
 
 # --- should_send_as_photo ---
@@ -214,79 +66,10 @@ class TestShouldSendAsPhoto:
         assert should_send_as_photo(img) is False
 
 
-# --- Deduplication ---
+# --- Constants ---
 
 
-class TestDeduplication:
-    def test_duplicate_paths_deduplicated(self, work_dir: Path, approved_dir: Path):
-        text = f"`{work_dir}/chart.png` is the same as `{work_dir}/chart.png`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-    def test_same_file_different_references(self, work_dir: Path, approved_dir: Path):
-        """Same resolved path via relative and absolute should deduplicate."""
-        text = f"`{work_dir}/chart.png` and `chart.png`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-
-# --- Cap ---
-
-
-class TestMaxCap:
-    def test_max_images_cap(self, tmp_path: Path):
-        """Should not return more than MAX_IMAGES_PER_RESPONSE images."""
-        img_dir = tmp_path / "many"
-        img_dir.mkdir()
-        names = []
-        for i in range(MAX_IMAGES_PER_RESPONSE + 5):
-            name = f"img_{i:03d}.png"
-            (img_dir / name).write_bytes(b"\x00" * 10)
-            names.append(name)
-
-        text = " ".join(f"`{img_dir / n}`" for n in names)
-        result = extract_images_from_response(text, img_dir, tmp_path)
-        assert len(result) == MAX_IMAGES_PER_RESPONSE
-
-
-# --- Edge cases ---
-
-
-class TestEdgeCases:
-    def test_empty_text(self, work_dir: Path, approved_dir: Path):
-        result = extract_images_from_response("", work_dir, approved_dir)
-        assert result == []
-
-    def test_no_image_references(self, work_dir: Path, approved_dir: Path):
-        text = "Here is some text with no image paths at all."
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert result == []
-
-    def test_case_insensitive_extension(self, work_dir: Path, approved_dir: Path):
-        """Extensions like .PNG or .Jpg should still match."""
-        upper = work_dir / "UPPER.PNG"
-        upper.write_bytes(b"\x00" * 100)
-        text = f"`{upper}`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-    def test_path_with_spaces(self, work_dir: Path, approved_dir: Path):
-        spaced = work_dir / "my chart.png"
-        spaced.write_bytes(b"\x00" * 100)
-        text = f'"{spaced}"'
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-
-    def test_all_supported_extensions(self, work_dir: Path, approved_dir: Path):
-        """Verify every extension in IMAGE_EXTENSIONS is detected."""
-        for ext in IMAGE_EXTENSIONS:
-            fname = f"test_file{ext}"
-            (work_dir / fname).write_bytes(b"\x00" * 10)
-
-        text = " ".join(f"`{work_dir / f'test_file{ext}'}`" for ext in IMAGE_EXTENSIONS)
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == len(IMAGE_EXTENSIONS)
-
+class TestConstants:
     def test_telegram_photo_extensions_subset(self):
         """TELEGRAM_PHOTO_EXTENSIONS should be a subset of IMAGE_EXTENSIONS keys."""
         for ext in TELEGRAM_PHOTO_EXTENSIONS:
@@ -295,94 +78,98 @@ class TestEdgeCases:
     def test_svg_not_in_photo_extensions(self):
         assert ".svg" not in TELEGRAM_PHOTO_EXTENSIONS
 
-    def test_image_attachment_fields(self, work_dir: Path, approved_dir: Path):
-        text = f"`{work_dir}/chart.png`"
-        result = extract_images_from_response(text, work_dir, approved_dir)
-        assert len(result) == 1
-        img = result[0]
-        assert isinstance(img, ImageAttachment)
-        assert img.mime_type == "image/png"
-        assert img.original_reference == f"{work_dir}/chart.png"
+
+# --- validate_image_path (MCP tool validation) ---
 
 
-# --- Tool-based extraction ---
+class TestValidateImagePath:
+    def test_valid_absolute_image(self, work_dir: Path, approved_dir: Path):
+        img = work_dir / "chart.png"
+        result = validate_image_path(str(img), approved_dir)
+        assert result is not None
+        assert result.path == img.resolve()
+        assert result.mime_type == "image/png"
 
+    def test_relative_path_rejected(self, approved_dir: Path):
+        result = validate_image_path("relative/chart.png", approved_dir)
+        assert result is None
 
-class TestToolBasedExtraction:
-    def test_read_tool_image_detected(self, work_dir: Path, approved_dir: Path):
-        """Images from Read tool calls should be detected even without text refs."""
-        tools_used = [
-            {"name": "Read", "input": {"file_path": f"{work_dir}/chart.png"}},
-        ]
-        result = extract_images_from_response(
-            "Here are the slides.", work_dir, approved_dir, tools_used=tools_used
-        )
-        assert len(result) == 1
-        assert result[0].path == (work_dir / "chart.png").resolve()
+    def test_nonexistent_file_rejected(self, work_dir: Path, approved_dir: Path):
+        result = validate_image_path(str(work_dir / "missing.png"), approved_dir)
+        assert result is None
 
-    def test_write_tool_image_detected(self, work_dir: Path, approved_dir: Path):
-        """Images from Write tool calls should be detected."""
-        tools_used = [
-            {"name": "Write", "input": {"file_path": f"{work_dir}/photo.jpg"}},
-        ]
-        result = extract_images_from_response(
-            "", work_dir, approved_dir, tools_used=tools_used
-        )
-        assert len(result) == 1
+    def test_non_image_extension_rejected(self, work_dir: Path, approved_dir: Path):
+        txt = work_dir / "notes.txt"
+        txt.write_text("hello")
+        result = validate_image_path(str(txt), approved_dir)
+        assert result is None
 
-    def test_non_image_tool_calls_ignored(self, work_dir: Path, approved_dir: Path):
-        """Read of non-image files should not produce results."""
-        tools_used = [
-            {"name": "Read", "input": {"file_path": f"{work_dir}/readme.txt"}},
-        ]
-        # Create the txt file so it exists
-        (work_dir / "readme.txt").write_text("hello")
-        result = extract_images_from_response(
-            "", work_dir, approved_dir, tools_used=tools_used
-        )
-        assert len(result) == 0
-
-    def test_tool_and_text_deduplicate(self, work_dir: Path, approved_dir: Path):
-        """Same image found in text and tool calls should not duplicate."""
-        tools_used = [
-            {"name": "Read", "input": {"file_path": f"{work_dir}/chart.png"}},
-        ]
-        text = f"I read `{work_dir}/chart.png`."
-        result = extract_images_from_response(
-            text, work_dir, approved_dir, tools_used=tools_used
-        )
-        assert len(result) == 1
-
-    def test_multiple_tool_images(self, work_dir: Path, approved_dir: Path):
-        """Multiple image tool calls should all be detected."""
-        tools_used = [
-            {"name": "Read", "input": {"file_path": f"{work_dir}/chart.png"}},
-            {"name": "Read", "input": {"file_path": f"{work_dir}/photo.jpg"}},
-            {"name": "Read", "input": {"file_path": f"{work_dir}/diagram.svg"}},
-        ]
-        result = extract_images_from_response(
-            "Here are the images.", work_dir, approved_dir, tools_used=tools_used
-        )
-        assert len(result) == 3
-
-    def test_tool_image_outside_approved_dir_rejected(
-        self, work_dir: Path, tmp_path: Path
-    ):
-        """Tool image paths outside approved dir should be rejected."""
+    def test_outside_approved_dir_rejected(self, tmp_path: Path):
         outside = tmp_path / "outside"
         outside.mkdir()
         img = outside / "evil.png"
         img.write_bytes(b"\x00" * 100)
+        # approved is a subdirectory, image is outside it
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        result = validate_image_path(str(img), approved)
+        assert result is None
 
-        tools_used = [{"name": "Read", "input": {"file_path": str(img)}}]
-        result = extract_images_from_response(
-            "", work_dir, work_dir, tools_used=tools_used
-        )
-        assert len(result) == 0
+    def test_caption_stored_as_original_reference(
+        self, work_dir: Path, approved_dir: Path
+    ):
+        img = work_dir / "chart.png"
+        result = validate_image_path(str(img), approved_dir, caption="My chart")
+        assert result is not None
+        assert result.original_reference == "My chart"
 
-    def test_no_tools_used(self, work_dir: Path, approved_dir: Path):
-        """None tools_used should work fine."""
-        result = extract_images_from_response(
-            "No images here.", work_dir, approved_dir, tools_used=None
-        )
-        assert len(result) == 0
+    def test_no_caption_uses_path(self, work_dir: Path, approved_dir: Path):
+        img = work_dir / "chart.png"
+        result = validate_image_path(str(img), approved_dir)
+        assert result is not None
+        assert result.original_reference == str(img)
+
+    def test_large_file_rejected(self, work_dir: Path, approved_dir: Path):
+        big = work_dir / "huge.png"
+        big.write_bytes(b"\x00" * 100)
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = MAX_FILE_SIZE_BYTES + 1
+            with patch.object(Path, "is_file", return_value=True):
+                result = validate_image_path(str(big), approved_dir)
+        assert result is None
+
+    def test_symlink_escaping_rejected(self, tmp_path: Path):
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        outside = tmp_path / "secret"
+        outside.mkdir()
+        secret_img = outside / "secret.png"
+        secret_img.write_bytes(b"\x00" * 100)
+        link = approved / "link.png"
+        link.symlink_to(secret_img)
+        result = validate_image_path(str(link), approved)
+        assert result is None
+
+    def test_all_supported_extensions(self, work_dir: Path, approved_dir: Path):
+        """Every extension in IMAGE_EXTENSIONS should be accepted."""
+        for ext in IMAGE_EXTENSIONS:
+            fname = f"test_file{ext}"
+            (work_dir / fname).write_bytes(b"\x00" * 10)
+            result = validate_image_path(str(work_dir / fname), approved_dir)
+            assert result is not None, f"Failed for {ext}"
+            assert result.mime_type == IMAGE_EXTENSIONS[ext]
+
+    def test_case_insensitive_extension(self, work_dir: Path, approved_dir: Path):
+        """Extensions like .PNG or .JPG should still match."""
+        upper = work_dir / "UPPER.PNG"
+        upper.write_bytes(b"\x00" * 100)
+        result = validate_image_path(str(upper), approved_dir)
+        assert result is not None
+
+    def test_image_attachment_fields(self, work_dir: Path, approved_dir: Path):
+        img = work_dir / "chart.png"
+        result = validate_image_path(str(img), approved_dir)
+        assert result is not None
+        assert isinstance(result, ImageAttachment)
+        assert result.mime_type == "image/png"
+        assert result.original_reference == str(img)

--- a/tests/unit/test_claude/test_sdk_integration.py
+++ b/tests/unit/test_claude/test_sdk_integration.py
@@ -100,6 +100,7 @@ class TestClaudeSDKManager:
             telegram_bot_username="testbot",
             approved_directory=tmp_path,
             claude_timeout_seconds=2,  # Short timeout for testing
+            enable_mcp=False,
         )
 
     @pytest.fixture

--- a/tests/unit/test_mcp/test_telegram_server.py
+++ b/tests/unit/test_mcp/test_telegram_server.py
@@ -1,0 +1,57 @@
+"""Tests for the Telegram MCP server tool functions."""
+
+from pathlib import Path
+
+import pytest
+
+from src.mcp.telegram_server import send_image_to_user
+
+
+@pytest.fixture
+def image_file(tmp_path: Path) -> Path:
+    """Create a sample image file."""
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    return img
+
+
+class TestSendImageToUser:
+    async def test_valid_image(self, image_file: Path) -> None:
+        result = await send_image_to_user(str(image_file))
+        assert "Image queued for delivery" in result
+        assert "chart.png" in result
+
+    async def test_valid_image_with_caption(self, image_file: Path) -> None:
+        result = await send_image_to_user(str(image_file), caption="My chart")
+        assert "Image queued for delivery" in result
+
+    async def test_relative_path_rejected(self, image_file: Path) -> None:
+        result = await send_image_to_user("relative/path/chart.png")
+        assert "Error" in result
+        assert "absolute" in result
+
+    async def test_missing_file_rejected(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.png"
+        result = await send_image_to_user(str(missing))
+        assert "Error" in result
+        assert "not found" in result
+
+    async def test_non_image_extension_rejected(self, tmp_path: Path) -> None:
+        txt_file = tmp_path / "notes.txt"
+        txt_file.write_text("hello")
+        result = await send_image_to_user(str(txt_file))
+        assert "Error" in result
+        assert "unsupported" in result
+
+    async def test_all_supported_extensions(self, tmp_path: Path) -> None:
+        for ext in [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"]:
+            img = tmp_path / f"test{ext}"
+            img.write_bytes(b"\x00" * 10)
+            result = await send_image_to_user(str(img))
+            assert "Image queued for delivery" in result, f"Failed for {ext}"
+
+    async def test_case_insensitive_extension(self, tmp_path: Path) -> None:
+        img = tmp_path / "photo.JPG"
+        img.write_bytes(b"\x00" * 10)
+        result = await send_image_to_user(str(img))
+        assert "Image queued for delivery" in result


### PR DESCRIPTION
  This PR introduces MCP (Model Context Protocol) integration to the project. A new MCP stdio server
  exposes custom tools that Claude can call during conversations. The first tool is send_image_to_user,
  which lets Claude send images to Telegram users explicitly rather than relying on regex-based guessing
  from response text.

  The MCP server lives in src/mcp/telegram_server.py and is built with FastMCP, making it straightforward
  to add more Telegram-specific tools in the future (e.g. send_file_to_user, send_notification,
  ask_user_confirmation, etc.). Adding a new tool is as simple as defining a new function decorated with
  @mcp.tool() in that file.

  How it works: when Claude calls send_image_to_user(file_path, caption), the stream callback intercepts
  the tool call, validates the path against the approved directory (symlink resolution, 50MB size cap,
  extension allowlisting), and collects the image. After the response completes, images are delivered to
  Telegram as inline photos (raster under 10MB) or as documents (SVG/large files). When the response text
  is short enough it gets embedded as a caption on the image.

  Files added: src/mcp/telegram_server.py (the MCP server), config/mcp.example.json (example config,
  actual mcp.json is gitignored), tests/unit/test_mcp/test_telegram_server.py.

  Files changed: src/bot/utils/image_extractor.py (stripped down to validate_image_path and
  should_send_as_photo), src/bot/orchestrator.py and src/bot/handlers/message.py (stream callback
  intercepts MCP tool calls), src/events/handlers.py, src/events/types.py, src/notifications/service.py
  (removed previous auto-detection code).

  All 428 tests pass, linting is clean.