### PR TITLE
Enable concurrent processing of messages across topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,21 @@ To use topics with your bot, enable them in BotFather:
 
 Message [@userinfobot](https://t.me/userinfobot) on Telegram -- it will reply with your user ID number.
 
+## Viewing Logs
+
+If running as a systemd user service (see [SYSTEMD_SETUP.md](SYSTEMD_SETUP.md)):
+
+```bash
+# Live logs (follow mode)
+journalctl --user -u claude-telegram-bot -f
+
+# Recent logs (last 50 lines)
+journalctl --user -u claude-telegram-bot -n 50
+
+# Check service status
+systemctl --user status claude-telegram-bot
+```
+
 ## Troubleshooting
 
 **Bot doesn't respond:**

--- a/src/bot/core.py
+++ b/src/bot/core.py
@@ -51,6 +51,7 @@ class ClaudeCodeBot:
         builder = Application.builder()
         builder.token(self.settings.telegram_token_str)
         builder.rate_limiter(AIORateLimiter(max_retries=1))
+        builder.concurrent_updates(True)
 
         # Configure connection settings
         builder.connect_timeout(30)


### PR DESCRIPTION
## Summary

- Store per-update thread state in a dict on the orchestrator instance instead of setting attributes on `telegram.Update` (which uses `__slots__` and raises `AttributeError`)
- Add `projects` and `tasks` to `_CLAUDE_INTERNAL_SUBDIRS` whitelist so Claude Code can read its own compressed tool results and task data
- Allow `/tmp/claude-<uid>/` paths for Task agent output files
- Add "Viewing Logs" section to README

Closes #102

## Test plan

- [ ] Send messages to multiple project topics concurrently and verify they are processed in parallel
- [ ] Verify plan mode works (writes to `~/.claude/plans/`)
- [ ] Verify long conversations work (Claude re-reads compressed tool results from `~/.claude/projects/`)
- [ ] Verify Task agent subprocesses work (reads from `/tmp/claude-<uid>/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)