### PR TITLE
Fix bot stopping mid-response on progress message deletion failure

### DIFF
--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -797,7 +797,10 @@ class MessageOrchestrator:
         finally:
             heartbeat.cancel()
 
-        await progress_msg.delete()
+        try:
+            await progress_msg.delete()
+        except Exception:
+            logger.debug("Failed to delete progress message, ignoring")
 
         for i, message in enumerate(formatted_messages):
             if not message.text or not message.text.strip():
@@ -964,7 +967,10 @@ class MessageOrchestrator:
                 claude_response.content
             )
 
-            await progress_msg.delete()
+            try:
+                await progress_msg.delete()
+            except Exception:
+                logger.debug("Failed to delete progress message, ignoring")
 
             for i, message in enumerate(formatted_messages):
                 await update.message.reply_text(
@@ -1054,7 +1060,10 @@ class MessageOrchestrator:
                 claude_response.content
             )
 
-            await progress_msg.delete()
+            try:
+                await progress_msg.delete()
+            except Exception:
+                logger.debug("Failed to delete progress message, ignoring")
 
             for i, message in enumerate(formatted_messages):
                 await update.message.reply_text(


### PR DESCRIPTION
The progress_msg.delete() call was unprotected in all agentic handlers (text, document, photo). If it throws (Telegram timeout, rate limit, message already deleted), the exception crashes the handler and the actual Claude response is never sent to the user. Wrap all three call sites in try-except so a deletion failure is logged but does not prevent delivering the response.