### PR TITLE
fix(orchestrator): route General topic in forum groups

### DIFF
--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -255,6 +255,11 @@ class MessageOrchestrator:
         topic_id = getattr(dm_topic, "topic_id", None) if dm_topic else None
         if isinstance(topic_id, int) and topic_id > 0:
             return topic_id
+        # Telegram omits message_thread_id for the General topic in forum
+        # supergroups; its canonical thread ID is 1.
+        chat = update.effective_chat
+        if chat and getattr(chat, "is_forum", False):
+            return 1
         return None
 
     async def _reject_for_thread_mode(self, update: Update, message: str) -> None:


### PR DESCRIPTION
## Summary
- Telegram omits `message_thread_id` for messages in the built-in General topic of forum supergroups
- `_extract_message_thread_id` returns `None`, so the routing guard rejects these messages
- This patch defaults to thread ID `1` (Telegram's canonical General topic ID) when the chat is a forum group and no thread ID is present

Closes #109

## Test plan
- [ ] Send a message in the General topic of a forum supergroup with `PROJECT_THREADS_MODE=group`
- [ ] Verify the message is routed to the project mapped to thread ID 1
- [ ] Verify non-forum chats are unaffected (still return `None`)
- [ ] Verify named topics still return their actual thread ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)