### PR TITLE
feat(config): add REPLY_QUOTE to control message quoting

### DIFF
--- a/src/bot/core.py
+++ b/src/bot/core.py
@@ -16,6 +16,7 @@ from telegram.ext import (
     AIORateLimiter,
     Application,
     ContextTypes,
+    Defaults,
     MessageHandler,
     filters,
 )
@@ -50,6 +51,7 @@ class ClaudeCodeBot:
         # Create application
         builder = Application.builder()
         builder.token(self.settings.telegram_token_str)
+        builder.defaults(Defaults(do_quote=self.settings.reply_quote))
         builder.rate_limiter(AIORateLimiter(max_retries=1))
 
         # Configure connection settings

--- a/src/bot/handlers/message.py
+++ b/src/bot/handlers/message.py
@@ -322,8 +322,7 @@ async def handle_text_message(
         # Create progress message
         progress_msg = await update.message.reply_text(
             "🤔 Processing your request...",
-            reply_to_message_id=(update.message.message_id if settings.reply_quote else None),
-            do_quote=settings.reply_quote,
+            reply_to_message_id=update.message.message_id,
         )
 
         # Get Claude integration and storage from context
@@ -422,8 +421,7 @@ async def handle_text_message(
                     message.text,
                     parse_mode=message.parse_mode,
                     reply_markup=message.reply_markup,
-                    reply_to_message_id=(update.message.message_id if i == 0 and settings.reply_quote else None),
-                    do_quote=settings.reply_quote,
+                    reply_to_message_id=update.message.message_id if i == 0 else None,
                 )
 
                 # Small delay between messages to avoid rate limits
@@ -441,9 +439,8 @@ async def handle_text_message(
                         message.text,
                         reply_markup=message.reply_markup,
                         reply_to_message_id=(
-                            update.message.message_id if i == 0 and settings.reply_quote else None
+                            update.message.message_id if i == 0 else None
                         ),
-                        do_quote=settings.reply_quote,
                     )
                 except Exception as plain_err:
                     logger.error(
@@ -456,9 +453,8 @@ async def handle_text_message(
                         f"(Telegram error: {str(plain_err)[:150]}). "
                         f"Please try again.",
                         reply_to_message_id=(
-                            update.message.message_id if i == 0 and settings.reply_quote else None
+                            update.message.message_id if i == 0 else None
                         ),
-                        do_quote=settings.reply_quote,
                     )
 
         # Update session info
@@ -734,8 +730,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                     message.text,
                     parse_mode=message.parse_mode,
                     reply_markup=message.reply_markup,
-                    reply_to_message_id=(update.message.message_id if i == 0 and settings.reply_quote else None),
-                    do_quote=settings.reply_quote,
+                    reply_to_message_id=(update.message.message_id if i == 0 else None),
                 )
 
                 if i < len(formatted_messages) - 1:
@@ -858,9 +853,8 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                         parse_mode=message.parse_mode,
                         reply_markup=message.reply_markup,
                         reply_to_message_id=(
-                            update.message.message_id if i == 0 and settings.reply_quote else None
+                            update.message.message_id if i == 0 else None
                         ),
-                        do_quote=settings.reply_quote,
                     )
 
                     if i < len(formatted_messages) - 1:

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -711,7 +711,7 @@ class MessageOrchestrator:
         await chat.send_action("typing")
 
         verbose_level = self._get_verbose_level(context)
-        progress_msg = await update.message.reply_text("Working...", do_quote=self.settings.reply_quote)
+        progress_msg = await update.message.reply_text("Working...")
 
         claude_integration = context.bot_data.get("claude_integration")
         if not claude_integration:
@@ -807,8 +807,7 @@ class MessageOrchestrator:
                     message.text,
                     parse_mode=message.parse_mode,
                     reply_markup=None,  # No keyboards in agentic mode
-                    reply_to_message_id=(update.message.message_id if i == 0 and self.settings.reply_quote else None),
-                    do_quote=self.settings.reply_quote,
+                    reply_to_message_id=(update.message.message_id if i == 0 else None),
                 )
                 if i < len(formatted_messages) - 1:
                     await asyncio.sleep(0.5)
@@ -823,7 +822,7 @@ class MessageOrchestrator:
                         message.text,
                         reply_markup=None,
                         reply_to_message_id=(
-                            update.message.message_id if i == 0 and self.settings.reply_quote else None
+                            update.message.message_id if i == 0 else None
                         ),
                     )
                 except Exception as plain_err:
@@ -832,7 +831,7 @@ class MessageOrchestrator:
                         f"(Telegram error: {str(plain_err)[:150]}). "
                         f"Please try again.",
                         reply_to_message_id=(
-                            update.message.message_id if i == 0 and self.settings.reply_quote else None
+                            update.message.message_id if i == 0 else None
                         ),
                     )
 
@@ -877,7 +876,7 @@ class MessageOrchestrator:
 
         chat = update.message.chat
         await chat.send_action("typing")
-        progress_msg = await update.message.reply_text("Working...", do_quote=self.settings.reply_quote)
+        progress_msg = await update.message.reply_text("Working...")
 
         # Try enhanced file handler, fall back to basic
         features = context.bot_data.get("features")
@@ -972,8 +971,7 @@ class MessageOrchestrator:
                     message.text,
                     parse_mode=message.parse_mode,
                     reply_markup=None,
-                    reply_to_message_id=(update.message.message_id if i == 0 and self.settings.reply_quote else None),
-                    do_quote=self.settings.reply_quote,
+                    reply_to_message_id=(update.message.message_id if i == 0 else None),
                 )
                 if i < len(formatted_messages) - 1:
                     await asyncio.sleep(0.5)
@@ -1001,7 +999,7 @@ class MessageOrchestrator:
 
         chat = update.message.chat
         await chat.send_action("typing")
-        progress_msg = await update.message.reply_text("Working...", do_quote=self.settings.reply_quote)
+        progress_msg = await update.message.reply_text("Working...")
 
         try:
             photo = update.message.photo[-1]
@@ -1063,8 +1061,7 @@ class MessageOrchestrator:
                     message.text,
                     parse_mode=message.parse_mode,
                     reply_markup=None,
-                    reply_to_message_id=(update.message.message_id if i == 0 and self.settings.reply_quote else None),
-                    do_quote=self.settings.reply_quote,
+                    reply_to_message_id=(update.message.message_id if i == 0 else None),
                 )
                 if i < len(formatted_messages) - 1:
                     await asyncio.sleep(0.5)


### PR DESCRIPTION
## Summary
- Adds `REPLY_QUOTE` env var (default: `true`) to control whether bot responses quote the original user message
- When `false`, responses are sent without the reply-quote bubble, giving cleaner thread-based conversations
- Applied consistently across agentic mode (orchestrator) and classic mode (message handler), including all fallback paths

## Usage
```env
# Disable reply quoting for cleaner threads
REPLY_QUOTE=false
```

## Test plan
- [ ] Default behaviour unchanged (`REPLY_QUOTE` unset or `true` → responses quote the user message)
- [ ] Setting `REPLY_QUOTE=false` → responses sent without quoting
- [ ] Fallback error messages also respect the setting
- [ ] Works in both agentic and classic mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)