### PR TITLE
fix: pass allowed_tools=None to SDK when DISABLE_TOOL_VALIDATION=true

### DIFF
--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -172,12 +172,22 @@ class ClaudeSDKManager:
                 logger.debug("Claude CLI stderr", line=line)
 
             # Build Claude Agent options
+            # When DISABLE_TOOL_VALIDATION=true, pass None for allowed/disallowed
+            # tools so the SDK does not restrict tool usage. This lets MCP tools
+            # (e.g. mcp__home-assistant__*) through at the SDK level.
+            if self.config.disable_tool_validation:
+                sdk_allowed_tools = None
+                sdk_disallowed_tools = None
+            else:
+                sdk_allowed_tools = self.config.claude_allowed_tools
+                sdk_disallowed_tools = self.config.claude_disallowed_tools
+
             options = ClaudeAgentOptions(
                 max_turns=self.config.claude_max_turns,
                 max_budget_usd=self.config.claude_max_cost_per_request,
                 cwd=str(working_directory),
-                allowed_tools=self.config.claude_allowed_tools,
-                disallowed_tools=self.config.claude_disallowed_tools,
+                allowed_tools=sdk_allowed_tools,
+                disallowed_tools=sdk_disallowed_tools,
                 cli_path=self.config.claude_cli_path,
                 sandbox={
                     "enabled": self.config.sandbox_enabled,

--- a/tests/unit/test_bot/test_middleware.py
+++ b/tests/unit/test_bot/test_middleware.py
@@ -35,6 +35,7 @@ def mock_settings():
     settings.enable_api_server = False
     settings.enable_scheduler = False
     settings.approved_directory = "/tmp/test"
+    settings.bot_language = "en"
     return settings
 
 

--- a/tests/unit/test_claude/test_sdk_integration.py
+++ b/tests/unit/test_claude/test_sdk_integration.py
@@ -516,6 +516,70 @@ class TestClaudeSandboxSettings:
         assert len(captured_options) == 1
         assert captured_options[0].allowed_tools == ["Read", "Write", "Bash"]
 
+    async def test_disable_tool_validation_sets_allowed_tools_none(self, tmp_path):
+        """Test allowed_tools=None when DISABLE_TOOL_VALIDATION=true."""
+        config = Settings(
+            telegram_bot_token="test:token",
+            telegram_bot_username="testbot",
+            approved_directory=tmp_path,
+            claude_timeout_seconds=2,
+            disable_tool_validation=True,
+            claude_allowed_tools=["Read", "Write", "Bash"],
+            claude_disallowed_tools=["WebFetch"],
+        )
+        manager = ClaudeSDKManager(config)
+
+        captured_options = []
+        mock_factory = _mock_client_factory(
+            _make_assistant_message("Test response"),
+            _make_result_message(total_cost_usd=0.01),
+            capture_options=captured_options,
+        )
+
+        with patch(
+            "src.claude.sdk_integration.ClaudeSDKClient", side_effect=mock_factory
+        ):
+            await manager.execute_command(
+                prompt="Test prompt",
+                working_directory=tmp_path,
+            )
+
+        assert len(captured_options) == 1
+        assert captured_options[0].allowed_tools is None
+        assert captured_options[0].disallowed_tools is None
+
+    async def test_tool_validation_enabled_passes_configured_tools(self, tmp_path):
+        """Test allowed/disallowed_tools are passed when DISABLE_TOOL_VALIDATION=false."""
+        config = Settings(
+            telegram_bot_token="test:token",
+            telegram_bot_username="testbot",
+            approved_directory=tmp_path,
+            claude_timeout_seconds=2,
+            disable_tool_validation=False,
+            claude_allowed_tools=["Read", "Write"],
+            claude_disallowed_tools=["WebFetch"],
+        )
+        manager = ClaudeSDKManager(config)
+
+        captured_options = []
+        mock_factory = _mock_client_factory(
+            _make_assistant_message("Test response"),
+            _make_result_message(total_cost_usd=0.01),
+            capture_options=captured_options,
+        )
+
+        with patch(
+            "src.claude.sdk_integration.ClaudeSDKClient", side_effect=mock_factory
+        ):
+            await manager.execute_command(
+                prompt="Test prompt",
+                working_directory=tmp_path,
+            )
+
+        assert len(captured_options) == 1
+        assert captured_options[0].allowed_tools == ["Read", "Write"]
+        assert captured_options[0].disallowed_tools == ["WebFetch"]
+
     async def test_sandbox_disabled_when_config_false(self, tmp_path):
         """Test sandbox is disabled when sandbox_enabled=False."""
         config = Settings(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -20,7 +20,9 @@ def tmp_dir():
 
 @pytest.fixture
 def agentic_settings(tmp_dir):
-    return create_test_config(approved_directory=str(tmp_dir), agentic_mode=True)
+    return create_test_config(
+        approved_directory=str(tmp_dir), agentic_mode=True, bot_language="en"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- When `DISABLE_TOOL_VALIDATION=true`, pass `allowed_tools=None` and `disallowed_tools=None` to `ClaudeAgentOptions` so the SDK does not restrict tool usage
- MCP tools (e.g. `mcp__home-assistant__*`) are no longer blocked at the SDK level when tool validation is disabled
- The `can_use_tool` callback continues to enforce file path and bash directory boundaries regardless

Closes #91

## Test plan

- [x] New test: `test_disable_tool_validation_sets_allowed_tools_none` — verifies `allowed_tools=None` when flag is true
- [x] New test: `test_tool_validation_enabled_passes_configured_tools` — verifies configured lists are passed when flag is false (default)
- [x] All 405 existing tests pass
- [ ] Manual test: enable MCP server, set `DISABLE_TOOL_VALIDATION=true`, verify MCP tools are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
