### PR TITLE
feat: forward unknown /commands to Claude as natural language

### DIFF
--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -840,8 +840,11 @@ class MessageOrchestrator:
         """
         message_text = update.message.text
         # Convert "/some_cmd args" -> "Run /some-cmd args" for Claude
-        cmd_text = message_text.replace("_", "-")
-        prompt = f"Run {cmd_text}"
+        # Only replace underscores in the command token, not in arguments
+        parts = message_text.split(maxsplit=1)
+        cmd = parts[0].replace("_", "-")
+        args = parts[1] if len(parts) > 1 else ""
+        prompt = f"Run {cmd} {args}".strip()
         # Note: Message objects are frozen in python-telegram-bot v20+,
         # so we pass the transformed text via override_text parameter
         # instead of mutating update.message.text directly.


### PR DESCRIPTION
## Summary

- Adds a catch-all handler for unrecognized slash commands (e.g. `/commit`, `/review`, `/tofu_at`) that forwards them to Claude via `agentic_text`
- Converts Telegram-safe underscored commands to hyphenated form (`/tofu_at` → `Run /tofu-at`) since Telegram bot commands don't support hyphens
- Uses an `override_text` parameter on `agentic_text()` instead of mutating `update.message.text`, which is frozen (immutable) in `python-telegram-bot` v20+

## Problem

Claude Code supports project-specific slash commands via `.claude/commands/*.md`. When users send these commands through the Telegram bot (e.g. `/tofu_at`, `/commit`), they hit the "unknown command" path and are silently dropped.

A naive fix of setting `update.message.text = prompt` causes `AttributeError: Attribute 'text' of class 'Message' can't be set!` because `Message` objects are frozen dataclasses in `python-telegram-bot` v22.x.

## Solution

1. Register a `filters.COMMAND` handler at group 10 (after built-in command handlers) to catch unrecognized commands
2. `_agentic_unknown_command()` transforms the command text and passes it via `override_text` parameter
3. `agentic_text()` accepts optional `override_text: str | None = None`, using it over `update.message.text` when provided

## Test plan

- [x] Send `/tofu_at` via Telegram → bot forwards `Run /tofu-at` to Claude (no `AttributeError`)
- [x] Send regular text message → `agentic_text` works as before (`override_text=None`)
- [x] Built-in commands (`/start`, `/new`, `/status`) still handled by their dedicated handlers
- [x] Verified with `python-telegram-bot` v22.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)