### PR TITLE
docs: add Linux aiolimiter DBus workaround to setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,22 @@ This project is currently under active development with the following status:
    make dev
    ```
    > **Linux users**: If `make dev` shows a `DBusErrorResponse` / `ItemNotFoundException`
-   > error for `aiolimiter`, this is a known Poetry keyring issue on Linux and is
-   > non-fatal — the install continues. However, `aiolimiter` may not be installed,
-   > which will cause 2 test failures. Fix it by running:
+   > error for `aiolimiter`, this is a known Poetry keyring issue on Linux. To prevent
+   > it, disable the keyring backend before running `make dev`:
+   > ```bash
+   > PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring make dev
+   > ```
+   > Or configure Poetry once to disable keyring globally:
+   > ```bash
+   > poetry config keyring.enabled false
+   > make dev
+   > ```
+   > If you already ran `make dev` and see 2 test failures, install `aiolimiter`
+   > manually and re-run tests:
    > ```bash
    > poetry run pip install aiolimiter
+   > make test
    > ```
-   > Then re-run `make test` to confirm all tests pass.
 
 3. **Set up configuration**:
    ```bash


### PR DESCRIPTION
## Description
Documents a known Linux-specific issue where Poetry fails to install 
`aiolimiter` due to a DBus/keyring error during `make dev`. The error 
is non-fatal so the install appears to succeed, but `aiolimiter` is 
missing at runtime — causing 2 test failures that are confusing to debug.

## Related Issue
N/A — discovered while setting up the dev environment on Linux (Ubuntu 24).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update

## Testing
- [x] Ran `make test` before fix: 2 failures
- [x] Ran `poetry run pip install aiolimiter` 
- [x] Ran `make test` after fix: 433 passed, 0 failures

## Checklist
- [x] Documentation updated
- [x] No breaking changes
- [x] Self-review completed