### PR TITLE
Fix: Explicitly set proxy for httpx client to prevent connection pool corruption

### DIFF
--- a/src/bot/core.py
+++ b/src/bot/core.py
@@ -64,6 +64,18 @@ class ClaudeCodeBot:
         builder.write_timeout(30)
         builder.pool_timeout(30)
 
+        # Explicitly set proxy from environment variables.
+        # This is necessary because python-telegram-bot's Application.builder()
+        # does not automatically use HTTP_PROXY/HTTPS_PROXY environment variables.
+        # Without this, the httpx connection pool can become corrupted when running
+        # behind a proxy, causing the bot to stop responding to messages.
+        import os
+
+        proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+        if proxy_url:
+            builder.proxy(proxy_url)
+            logger.info("Proxy configured", proxy=proxy_url)
+
         self.app = builder.build()
 
         # Initialize feature registry


### PR DESCRIPTION
## Problem

When running behind a proxy (e.g., Clash, V2Ray), the bot's polling loop can get stuck even if `HTTP_PROXY`/`HTTPS_PROXY` environment variables are set. The httpx connection pool becomes corrupted after network interruptions, and the bot stops responding to messages while the process is still running.

## Root Cause

python-telegram-bot's `Application.builder()` does not automatically use the `HTTP_PROXY`/`HTTPS_PROXY` environment variables for its httpx client. The proxy needs to be explicitly set via `builder.proxy()`.

## Solution

Explicitly read proxy from environment variables and pass it to the Application builder:

```python
import os
proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
if proxy_url:
    builder.proxy(proxy_url)
    logger.info("Proxy configured", proxy=proxy_url)
```

## Testing

- Bot now correctly uses proxy for Telegram API calls
- Polling loop remains stable after network interruptions
- Tested with Clash proxy on macOS

## Related Issues

This partially addresses issues where bots stop responding after running for some time behind proxies.