### PR TITLE
✨ feat(topics): agregar comando /topics para gestionar project threads

### DIFF
--- a/.agents/skills/fastapi/SKILL.md
+++ b/.agents/skills/fastapi/SKILL.md
@@ -1,0 +1,436 @@
+---
+name: fastapi
+description: FastAPI best practices and conventions. Use when working with FastAPI APIs and Pydantic models for them. Keeps FastAPI code clean and up to date with the latest features and patterns, updated with new versions. Write new code or refactor and update old code.
+---
+
+# FastAPI
+
+Official FastAPI skill to write code with best practices, keeping up to date with new versions and features.
+
+## Use the `fastapi` CLI
+
+Run the development server on localhost with reload:
+
+```bash
+fastapi dev
+```
+
+
+Run the production server:
+
+```bash
+fastapi run
+```
+
+### Add an entrypoint in `pyproject.toml`
+
+FastAPI CLI will read the entrypoint in `pyproject.toml` to know where the FastAPI app is declared.
+
+```toml
+[tool.fastapi]
+entrypoint = "my_app.main:app"
+```
+
+### Use `fastapi` with a path
+
+When adding the entrypoint to `pyproject.toml` is not possible, or the user explicitly asks not to, or it's running an independent small app, you can pass the app file path to the `fastapi` command:
+
+```bash
+fastapi dev my_app/main.py
+```
+
+Prefer to set the entrypoint in `pyproject.toml` when possible.
+
+## Use `Annotated`
+
+Always prefer the `Annotated` style for parameter and dependency declarations.
+
+It keeps the function signatures working in other contexts, respects the types, allows reusability.
+
+### In Parameter Declarations
+
+Use `Annotated` for parameter declarations, including `Path`, `Query`, `Header`, etc.:
+
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, Path, Query
+
+app = FastAPI()
+
+
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: Annotated[int, Path(ge=1, description="The item ID")],
+    q: Annotated[str | None, Query(max_length=50)] = None,
+):
+    return {"message": "Hello World"}
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: int = Path(ge=1, description="The item ID"),
+    q: str | None = Query(default=None, max_length=50),
+):
+    return {"message": "Hello World"}
+```
+
+### For Dependencies
+
+Use `Annotated` for dependencies with `Depends()`.
+
+Unless asked not to, create a new type alias for the dependency to allow re-using it.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_current_user():
+    return {"username": "johndoe"}
+
+
+CurrentUserDep = Annotated[dict, Depends(get_current_user)]
+
+
+@app.get("/items/")
+async def read_item(current_user: CurrentUserDep):
+    return {"message": "Hello World"}
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+@app.get("/items/")
+async def read_item(current_user: dict = Depends(get_current_user)):
+    return {"message": "Hello World"}
+```
+
+## Do not use Ellipsis for *path operations* or Pydantic models
+
+Do not use `...` as a default value for required parameters, it's not needed and not recommended.
+
+Do this, without Ellipsis (`...`):
+
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, Query
+from pydantic import BaseModel, Field
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+    price: float = Field(gt=0)
+
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(item: Item, project_id: Annotated[int, Query()]): ...
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+class Item(BaseModel):
+    name: str = ...
+    description: str | None = None
+    price: float = Field(..., gt=0)
+
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(item: Item, project_id: Annotated[int, Query(...)]): ...
+```
+
+## Return Type or Response Model
+
+When possible, include a return type. It will be used to validate, filter, document, and serialize the response.
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me")
+async def get_item() -> Item:
+    return Item(name="Plumbus", description="All-purpose home device")
+```
+
+**Important**: Return types or response models are what filter data ensuring no sensitive information is exposed. And they are used to serialize data with Pydantic (in Rust), this is the main idea that can increase response performance.
+
+The return type doesn't have to be a Pydantic model, it could be a different type, like a list of integers, or a dict, etc.
+
+### When to use `response_model` instead
+
+If the return type is not the same as the type that you want to use to validate, filter, or serialize, use the `response_model` parameter on the decorator instead.
+
+```python
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me", response_model=Item)
+async def get_item() -> Any:
+    return {"name": "Foo", "description": "A very nice Item"}
+```
+
+This can be particularly useful when filtering data to expose only the public fields and avoid exposing sensitive information.
+
+```python
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class InternalItem(BaseModel):
+    name: str
+    description: str | None = None
+    secret_key: str
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me", response_model=Item)
+async def get_item() -> Any:
+    item = InternalItem(
+        name="Foo", description="A very nice Item", secret_key="supersecret"
+    )
+    return item
+```
+
+## Performance
+
+Do not use `ORJSONResponse` or `UJSONResponse`, they are deprecated.
+
+Instead, declare a return type or response model. Pydantic will handle the data serialization on the Rust side.
+
+## Including Routers
+
+When declaring routers, prefer to add router level parameters like prefix, tags, etc. to the router itself, instead of in `include_router()`.
+
+Do this:
+
+```python
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+router = APIRouter(prefix="/items", tags=["items"])
+
+
+@router.get("/")
+async def list_items():
+    return []
+
+
+# In main.py
+app.include_router(router)
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_items():
+    return []
+
+
+# In main.py
+app.include_router(router, prefix="/items", tags=["items"])
+```
+
+There could be exceptions, but try to follow this convention.
+
+Apply shared dependencies at the router level via `dependencies=[Depends(...)]`.
+
+## Dependency Injection
+
+See [the dependency injection reference](references/dependencies.md) for detailed patterns including `yield` with `scope`, and class dependencies.
+
+Use dependencies when the logic can't be declared in Pydantic validation, depends on external resources, needs cleanup (with `yield`), or is shared across endpoints.
+
+Apply shared dependencies at the router level via `dependencies=[Depends(...)]`.
+
+## Async vs Sync *path operations*
+
+Use `async` *path operations* only when fully certain that the logic called inside is compatible with async and await (it's called with `await`) or that doesn't block.
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+# Use async def when calling async code
+@app.get("/async-items/")
+async def read_async_items():
+    data = await some_async_library.fetch_items()
+    return data
+
+
+# Use plain def when calling blocking/sync code or when in doubt
+@app.get("/items/")
+def read_items():
+    data = some_blocking_library.fetch_items()
+    return data
+```
+
+In case of doubt, or by default, use regular `def` functions, those will be run in a threadpool so they don't block the event loop.
+
+The same rules apply to dependencies.
+
+Make sure blocking code is not run inside of `async` functions. The logic will work, but will damage the performance heavily.
+
+When needing to mix blocking and async code, see Asyncer in [the other tools reference](references/other-tools.md).
+
+## Streaming (JSON Lines, SSE, bytes)
+
+See [the streaming reference](references/streaming.md) for JSON Lines, Server-Sent Events (`EventSourceResponse`, `ServerSentEvent`), and byte streaming (`StreamingResponse`) patterns.
+
+## Tooling
+
+See [the other tools reference](references/other-tools.md) for details on uv, Ruff, ty for package management, linting, type checking, formatting, etc.
+
+## Other Libraries
+
+See [the other tools reference](references/other-tools.md) for details on other libraries:
+
+* Asyncer for handling async and await, concurrency, mixing async and blocking code, prefer it over AnyIO or asyncio.
+* SQLModel for working with SQL databases, prefer it over SQLAlchemy.
+* HTTPX for interacting with HTTP (other APIs), prefer it over Requests.
+
+## Do not use Pydantic RootModels
+
+Do not use Pydantic `RootModel`, instead use regular type annotations with `Annotated` and Pydantic validation utilities.
+
+For example, for a list with validations you could do:
+
+```python
+from typing import Annotated
+
+from fastapi import Body, FastAPI
+from pydantic import Field
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_items(items: Annotated[list[int], Field(min_length=1), Body()]):
+    return items
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+from typing import Annotated
+
+from fastapi import FastAPI
+from pydantic import Field, RootModel
+
+app = FastAPI()
+
+
+class ItemList(RootModel[Annotated[list[int], Field(min_length=1)]]):
+    pass
+
+
+@app.post("/items/")
+async def create_items(items: ItemList):
+    return items
+
+```
+
+FastAPI supports these type annotations and will create a Pydantic `TypeAdapter` for them, so that types can work as normally and there's no need for the custom logic and types in RootModels.
+
+## Use one HTTP operation per function
+
+Don't mix HTTP operations in a single function, having one function per HTTP operation helps separate concerns and organize the code.
+
+Do this:
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+
+
+@app.get("/items/")
+async def list_items():
+    return []
+
+
+@app.post("/items/")
+async def create_item(item: Item):
+    return item
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+
+
+@app.api_route("/items/", methods=["GET", "POST"])
+async def handle_items(request: Request):
+    if request.method == "GET":
+        return []
+```

--- a/.agents/skills/fastapi/references/dependencies.md
+++ b/.agents/skills/fastapi/references/dependencies.md
@@ -1,0 +1,142 @@
+# Dependency Injection
+
+Use dependencies when:
+
+* They can't be declared in Pydantic validation and require additional logic
+* The logic depends on external resources or could block in any other way
+* Other dependencies need their results (it's a sub-dependency)
+* The logic can be shared by multiple endpoints to do things like error early, authentication, etc.
+* They need to handle cleanup (e.g., DB sessions, file handles), using dependencies with `yield`
+* Their logic needs input data from the request, like headers, query parameters, etc.
+
+## Dependencies with `yield` and `scope`
+
+When using dependencies with `yield`, they can have a `scope` that defines when the exit code is run.
+
+Use the default scope `"request"` to run the exit code after the response is sent back.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_db():
+    db = DBSession()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+DBDep = Annotated[DBSession, Depends(get_db)]
+
+
+@app.get("/items/")
+async def read_items(db: DBDep):
+    return db.query(Item).all()
+```
+
+Use the scope `"function"` when they should run the exit code after the response data is generated but before the response is sent back to the client.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_username():
+    try:
+        yield "Rick"
+    finally:
+        print("Cleanup up before response is sent")
+
+UserNameDep = Annotated[str, Depends(get_username, scope="function")]
+
+@app.get("/users/me")
+def get_user_me(username: UserNameDep):
+    return username
+```
+
+## Class Dependencies
+
+Avoid creating class dependencies when possible.
+
+If a class is needed, instead create a regular function dependency that returns a class instance.
+
+Do this:
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+@dataclass
+class DatabasePaginator:
+    offset: int = 0
+    limit: int = 100
+    q: str | None = None
+
+    def get_page(self) -> dict:
+        # Simulate a page of data
+        return {
+            "offset": self.offset,
+            "limit": self.limit,
+            "q": self.q,
+            "items": [],
+        }
+
+
+def get_db_paginator(
+    offset: int = 0, limit: int = 100, q: str | None = None
+) -> DatabasePaginator:
+    return DatabasePaginator(offset=offset, limit=limit, q=q)
+
+
+PaginatorDep = Annotated[DatabasePaginator, Depends(get_db_paginator)]
+
+
+@app.get("/items/")
+async def read_items(paginator: PaginatorDep):
+    return paginator.get_page()
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+class DatabasePaginator:
+    def __init__(self, offset: int = 0, limit: int = 100, q: str | None = None):
+        self.offset = offset
+        self.limit = limit
+        self.q = q
+
+    def get_page(self) -> dict:
+        # Simulate a page of data
+        return {
+            "offset": self.offset,
+            "limit": self.limit,
+            "q": self.q,
+            "items": [],
+        }
+
+
+@app.get("/items/")
+async def read_items(paginator: Annotated[DatabasePaginator, Depends()]):
+    return paginator.get_page()
+```

--- a/.agents/skills/fastapi/references/other-tools.md
+++ b/.agents/skills/fastapi/references/other-tools.md
@@ -1,0 +1,76 @@
+# Other Tools
+
+## uv
+
+If uv is available, use it to manage dependencies.
+
+## Ruff
+
+If Ruff is available, use it to lint and format the code. Consider enabling the FastAPI rules.
+
+## ty
+
+If ty is available, use it to check types.
+
+## Asyncer
+
+When needing to run blocking code inside of async functions, or async code inside of blocking functions, suggest using Asyncer.
+
+Prefer it over AnyIO or asyncio.
+
+Install:
+
+```bash
+uv add asyncer
+```
+
+Run blocking sync code inside of async with `asyncify()`:
+
+```python
+from asyncer import asyncify
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+def do_blocking_work(name: str) -> str:
+    # Some blocking I/O operation
+    return f"Hello {name}"
+
+
+@app.get("/items/")
+async def read_items():
+    result = await asyncify(do_blocking_work)(name="World")
+    return {"message": result}
+```
+
+And run async code inside of blocking sync code with `syncify()`:
+
+```python
+from asyncer import syncify
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+async def do_async_work(name: str) -> str:
+    return f"Hello {name}"
+
+
+@app.get("/items/")
+def read_items():
+    result = syncify(do_async_work)(name="World")
+    return {"message": result}
+```
+
+## SQLModel for SQL databases
+
+When working with SQL databases, prefer using SQLModel as it is integrated with Pydantic and will allow declaring data validation with the same models.
+
+Prefer it over SQLAlchemy.
+
+## HTTPX
+
+Use HTTPX for handling HTTP communication (e.g. with other APIs). It support sync and async usage.
+
+Prefer it over Requests.

--- a/.agents/skills/fastapi/references/streaming.md
+++ b/.agents/skills/fastapi/references/streaming.md
@@ -1,0 +1,105 @@
+# Streaming
+
+## Stream JSON Lines
+
+To stream JSON Lines, declare the return type and use `yield` to return the data.
+
+```python
+@app.get("/items/stream")
+async def stream_items() -> AsyncIterable[Item]:
+    for item in items:
+        yield item
+```
+
+## Server-Sent Events (SSE)
+
+To stream Server-Sent Events, use `response_class=EventSourceResponse` and `yield` items from the endpoint.
+
+Plain objects are automatically JSON-serialized as `data:` fields, declare the return type so the serialization is done by Pydantic:
+
+```python
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+@app.get("/items/stream", response_class=EventSourceResponse)
+async def stream_items() -> AsyncIterable[Item]:
+    yield Item(name="Plumbus", price=32.99)
+    yield Item(name="Portal Gun", price=999.99)
+```
+
+For full control over SSE fields (`event`, `id`, `retry`, `comment`), yield `ServerSentEvent` instances:
+
+```python
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+
+app = FastAPI()
+
+
+@app.get("/events", response_class=EventSourceResponse)
+async def stream_events() -> AsyncIterable[ServerSentEvent]:
+    yield ServerSentEvent(data={"status": "started"}, event="status", id="1")
+    yield ServerSentEvent(data={"progress": 50}, event="progress", id="2")
+```
+
+Use `raw_data` instead of `data` to send pre-formatted strings without JSON encoding:
+
+```python
+yield ServerSentEvent(raw_data="plain text line", event="log")
+```
+
+## Stream bytes
+
+To stream bytes, declare a `response_class=` of `StreamingResponse` or a sub-class, and use `yield` to return the data.
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.utils import read_image
+
+app = FastAPI()
+
+
+class PNGStreamingResponse(StreamingResponse):
+    media_type = "image/png"
+
+@app.get("/image", response_class=PNGStreamingResponse)
+def stream_image_no_async_no_annotation():
+    with read_image() as image_file:
+        yield from image_file
+```
+
+prefer this over returning a `StreamingResponse` directly:
+
+```python
+# DO NOT DO THIS
+
+import anyio
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.utils import read_image
+
+app = FastAPI()
+
+
+class PNGStreamingResponse(StreamingResponse):
+    media_type = "image/png"
+
+
+@app.get("/")
+async def main():
+    return PNGStreamingResponse(read_image())
+```

--- a/.agents/skills/git-rules/SKILL.md
+++ b/.agents/skills/git-rules/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: git-rules
+description: Git workflow assistant for Paul Osinga — commits con Gitmoji, PRs en GitHub, branches en PascalCase y code review. Usa este skill cuando el usuario pida hacer commits, crear branches, abrir PRs, o revisar código con Git/GitHub. NUNCA, NO NEGOCIABLE incluir a Claude u otra IA o modelo como co-autor.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# Git Workflow
+
+Eres el asistente de Git. Manejas commits, PRs, branches y code review en GitHub.
+
+## REGLAS ABSOLUTAS
+
+1. **NUNCA** agregar `Co-Authored-By: Claude` ni ninguna mención a Claude/Anthropic en commits, PRs, títulos, descripciones ni mensajes.
+2. **NUNCA** usar `--no-verify` ni saltarte hooks.
+3. **NUNCA** hacer force push a `main` o `master`.
+4. Siempre usar `gh` CLI para operaciones de GitHub.
+5. Stagear archivos específicos — nunca `git add -A` sin revisar primero.
+
+---
+
+## Commits
+
+### Formato
+
+```
+<gitmoji> <tipo>(<scope opcional>): <descripción corta en imperativo>
+
+<cuerpo opcional>
+```
+
+### Tabla de Gitmoji
+
+| Emoji | Código | Cuándo |
+|-------|--------|--------|
+| ✨ | `:sparkles:` | Nueva funcionalidad |
+| 🐛 | `:bug:` | Fix de bug |
+| 🚑️ | `:ambulance:` | Fix crítico / hotfix |
+| 🎨 | `:art:` | Mejorar estructura/formato |
+| ⚡️ | `:zap:` | Mejora de rendimiento |
+| 📝 | `:memo:` | Documentación |
+| 🔧 | `:wrench:` | Config / archivos de configuración |
+| ♻️ | `:recycle:` | Refactor |
+| 🗑️ | `:wastebasket:` | Eliminar código/archivos |
+| 🚚 | `:truck:` | Mover/renombrar archivos |
+| 🔒️ | `:lock:` | Fix de seguridad |
+| ⬆️ | `:arrow_up:` | Actualizar dependencias |
+| 🏗️ | `:building_construction:` | Cambios arquitectónicos |
+| 🚀 | `:rocket:` | Deploy/release |
+| ✅ | `:white_check_mark:` | Tests |
+| 🔥 | `:fire:` | Eliminar código muerto |
+| 💄 | `:lipstick:` | UI/estilos |
+| 🌐 | `:globe_with_meridians:` | i18n/l10n |
+| 🐳 | `:whale:` | Docker |
+
+### Cómo hacer un commit
+
+1. Revisar `git status` y `git diff` para entender los cambios.
+2. Elegir el gitmoji correcto según el tipo de cambio.
+3. Stagear solo los archivos relevantes.
+4. Escribir el mensaje en imperativo, en español o inglés según el proyecto.
+
+```bash
+git add <archivos específicos>
+git commit -m "$(cat <<'EOF'
+✨ feat(notifications): agregar guard wasRecentlyCreated en discover_notification
+EOF
+)"
+```
+
+---
+
+## Branches
+
+### Nomenclatura — PascalCase, sin guiones ni underscores
+
+```
+<Tipo>/<DescripcionEnPascalCase>
+```
+
+| Tipo | Cuándo |
+|------|--------|
+| `Feat/` | Nueva funcionalidad |
+| `Fix/` | Bug fix |
+| `Hotfix/` | Fix urgente en producción |
+| `Refactor/` | Refactor sin cambio funcional |
+| `Chore/` | Mantenimiento, config, deps |
+| `Docs/` | Solo documentación |
+
+**Ejemplos:**
+- `Feat/DiscoverNotificationLaravel`
+- `Fix/DuplicateFcmNotification`
+- `Hotfix/CriticalAuthError`
+- `Chore/K8sCronjobCleanup`
+
+```bash
+git checkout -b Feat/NombreDescriptivo
+git push -u origin Feat/NombreDescriptivo
+```
+
+---
+
+## Pull Requests
+
+### Título — con Gitmoji
+
+```
+✨ feat: descripción concisa del cambio
+```
+
+### Cuerpo
+
+```markdown
+## Que hace este PR?
+<1-3 bullets concisos>
+
+## Por que?
+<contexto y motivacion>
+
+## Como probarlo?
+- [ ] paso 1
+- [ ] paso 2
+```
+
+### Crear PR con gh
+
+```bash
+gh pr create \
+  --title "✨ feat: descripción" \
+  --body "$(cat <<'EOF'
+## Que hace este PR?
+- ...
+
+## Por que?
+...
+
+## Como probarlo?
+- [ ] ...
+EOF
+)"
+```
+
+---
+
+## Code Review
+
+Al revisar un PR:
+
+1. `gh pr checkout <número>` para revisar localmente.
+2. `gh pr diff <número>` para ver los cambios.
+3. `gh pr view <número> --comments` para ver comentarios existentes.
+4. Comentar: `gh pr review <número> --comment -b "mensaje"`
+5. Aprobar: `gh pr review <número> --approve`
+6. Solicitar cambios: `gh pr review <número> --request-changes -b "motivo"`
+
+### Criterios de review
+
+- El cambio hace lo que dice el titulo/descripcion?
+- Hay riesgos de regresion o side effects?
+- El codigo es legible sin comentarios innecesarios?
+- Los tests cubren el caso?

--- a/.agents/skills/python-performance-optimization/SKILL.md
+++ b/.agents/skills/python-performance-optimization/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: python-performance-optimization
+description: Profile and optimize Python code using cProfile, memory profilers, and performance best practices. Use when debugging slow Python code, optimizing bottlenecks, or improving application performance.
+---
+
+# Python Performance Optimization
+
+Comprehensive guide to profiling, analyzing, and optimizing Python code for better performance, including CPU profiling, memory optimization, and implementation best practices.
+
+## When to Use This Skill
+
+- Identifying performance bottlenecks in Python applications
+- Reducing application latency and response times
+- Optimizing CPU-intensive operations
+- Reducing memory consumption and memory leaks
+- Improving database query performance
+- Optimizing I/O operations
+- Speeding up data processing pipelines
+- Implementing high-performance algorithms
+- Profiling production applications
+
+## Core Concepts
+
+### 1. Profiling Types
+
+- **CPU Profiling**: Identify time-consuming functions
+- **Memory Profiling**: Track memory allocation and leaks
+- **Line Profiling**: Profile at line-by-line granularity
+- **Call Graph**: Visualize function call relationships
+
+### 2. Performance Metrics
+
+- **Execution Time**: How long operations take
+- **Memory Usage**: Peak and average memory consumption
+- **CPU Utilization**: Processor usage patterns
+- **I/O Wait**: Time spent on I/O operations
+
+### 3. Optimization Strategies
+
+- **Algorithmic**: Better algorithms and data structures
+- **Implementation**: More efficient code patterns
+- **Parallelization**: Multi-threading/processing
+- **Caching**: Avoid redundant computation
+- **Native Extensions**: C/Rust for critical paths
+
+## Quick Start
+
+### Basic Timing
+
+```python
+import time
+
+def measure_time():
+    """Simple timing measurement."""
+    start = time.time()
+
+    # Your code here
+    result = sum(range(1000000))
+
+    elapsed = time.time() - start
+    print(f"Execution time: {elapsed:.4f} seconds")
+    return result
+
+# Better: use timeit for accurate measurements
+import timeit
+
+execution_time = timeit.timeit(
+    "sum(range(1000000))",
+    number=100
+)
+print(f"Average time: {execution_time/100:.6f} seconds")
+```
+
+## Profiling Tools
+
+### Pattern 1: cProfile - CPU Profiling
+
+```python
+import cProfile
+import pstats
+from pstats import SortKey
+
+def slow_function():
+    """Function to profile."""
+    total = 0
+    for i in range(1000000):
+        total += i
+    return total
+
+def another_function():
+    """Another function."""
+    return [i**2 for i in range(100000)]
+
+def main():
+    """Main function to profile."""
+    result1 = slow_function()
+    result2 = another_function()
+    return result1, result2
+
+# Profile the code
+if __name__ == "__main__":
+    profiler = cProfile.Profile()
+    profiler.enable()
+
+    main()
+
+    profiler.disable()
+
+    # Print stats
+    stats = pstats.Stats(profiler)
+    stats.sort_stats(SortKey.CUMULATIVE)
+    stats.print_stats(10)  # Top 10 functions
+
+    # Save to file for later analysis
+    stats.dump_stats("profile_output.prof")
+```
+
+**Command-line profiling:**
+
+```bash
+# Profile a script
+python -m cProfile -o output.prof script.py
+
+# View results
+python -m pstats output.prof
+# In pstats:
+# sort cumtime
+# stats 10
+```
+
+### Pattern 2: line_profiler - Line-by-Line Profiling
+
+```python
+# Install: pip install line-profiler
+
+# Add @profile decorator (line_profiler provides this)
+@profile
+def process_data(data):
+    """Process data with line profiling."""
+    result = []
+    for item in data:
+        processed = item * 2
+        result.append(processed)
+    return result
+
+# Run with:
+# kernprof -l -v script.py
+```
+
+**Manual line profiling:**
+
+```python
+from line_profiler import LineProfiler
+
+def process_data(data):
+    """Function to profile."""
+    result = []
+    for item in data:
+        processed = item * 2
+        result.append(processed)
+    return result
+
+if __name__ == "__main__":
+    lp = LineProfiler()
+    lp.add_function(process_data)
+
+    data = list(range(100000))
+
+    lp_wrapper = lp(process_data)
+    lp_wrapper(data)
+
+    lp.print_stats()
+```
+
+### Pattern 3: memory_profiler - Memory Usage
+
+```python
+# Install: pip install memory-profiler
+
+from memory_profiler import profile
+
+@profile
+def memory_intensive():
+    """Function that uses lots of memory."""
+    # Create large list
+    big_list = [i for i in range(1000000)]
+
+    # Create large dict
+    big_dict = {i: i**2 for i in range(100000)}
+
+    # Process data
+    result = sum(big_list)
+
+    return result
+
+if __name__ == "__main__":
+    memory_intensive()
+
+# Run with:
+# python -m memory_profiler script.py
+```
+
+### Pattern 4: py-spy - Production Profiling
+
+```bash
+# Install: pip install py-spy
+
+# Profile a running Python process
+py-spy top --pid 12345
+
+# Generate flamegraph
+py-spy record -o profile.svg --pid 12345
+
+# Profile a script
+py-spy record -o profile.svg -- python script.py
+
+# Dump current call stack
+py-spy dump --pid 12345
+```
+
+## Optimization Patterns
+
+### Pattern 5: List Comprehensions vs Loops
+
+```python
+import timeit
+
+# Slow: Traditional loop
+def slow_squares(n):
+    """Create list of squares using loop."""
+    result = []
+    for i in range(n):
+        result.append(i**2)
+    return result
+
+# Fast: List comprehension
+def fast_squares(n):
+    """Create list of squares using comprehension."""
+    return [i**2 for i in range(n)]
+
+# Benchmark
+n = 100000
+
+slow_time = timeit.timeit(lambda: slow_squares(n), number=100)
+fast_time = timeit.timeit(lambda: fast_squares(n), number=100)
+
+print(f"Loop: {slow_time:.4f}s")
+print(f"Comprehension: {fast_time:.4f}s")
+print(f"Speedup: {slow_time/fast_time:.2f}x")
+
+# Even faster for simple operations: map
+def faster_squares(n):
+    """Use map for even better performance."""
+    return list(map(lambda x: x**2, range(n)))
+```
+
+### Pattern 6: Generator Expressions for Memory
+
+```python
+import sys
+
+def list_approach():
+    """Memory-intensive list."""
+    data = [i**2 for i in range(1000000)]
+    return sum(data)
+
+def generator_approach():
+    """Memory-efficient generator."""
+    data = (i**2 for i in range(1000000))
+    return sum(data)
+
+# Memory comparison
+list_data = [i for i in range(1000000)]
+gen_data = (i for i in range(1000000))
+
+print(f"List size: {sys.getsizeof(list_data)} bytes")
+print(f"Generator size: {sys.getsizeof(gen_data)} bytes")
+
+# Generators use constant memory regardless of size
+```
+
+### Pattern 7: String Concatenation
+
+```python
+import timeit
+
+def slow_concat(items):
+    """Slow string concatenation."""
+    result = ""
+    for item in items:
+        result += str(item)
+    return result
+
+def fast_concat(items):
+    """Fast string concatenation with join."""
+    return "".join(str(item) for item in items)
+
+def faster_concat(items):
+    """Even faster with list."""
+    parts = [str(item) for item in items]
+    return "".join(parts)
+
+items = list(range(10000))
+
+# Benchmark
+slow = timeit.timeit(lambda: slow_concat(items), number=100)
+fast = timeit.timeit(lambda: fast_concat(items), number=100)
+faster = timeit.timeit(lambda: faster_concat(items), number=100)
+
+print(f"Concatenation (+): {slow:.4f}s")
+print(f"Join (generator): {fast:.4f}s")
+print(f"Join (list): {faster:.4f}s")
+```
+
+### Pattern 8: Dictionary Lookups vs List Searches
+
+```python
+import timeit
+
+# Create test data
+size = 10000
+items = list(range(size))
+lookup_dict = {i: i for i in range(size)}
+
+def list_search(items, target):
+    """O(n) search in list."""
+    return target in items
+
+def dict_search(lookup_dict, target):
+    """O(1) search in dict."""
+    return target in lookup_dict
+
+target = size - 1  # Worst case for list
+
+# Benchmark
+list_time = timeit.timeit(
+    lambda: list_search(items, target),
+    number=1000
+)
+dict_time = timeit.timeit(
+    lambda: dict_search(lookup_dict, target),
+    number=1000
+)
+
+print(f"List search: {list_time:.6f}s")
+print(f"Dict search: {dict_time:.6f}s")
+print(f"Speedup: {list_time/dict_time:.0f}x")
+```
+
+### Pattern 9: Local Variable Access
+
+```python
+import timeit
+
+# Global variable (slow)
+GLOBAL_VALUE = 100
+
+def use_global():
+    """Access global variable."""
+    total = 0
+    for i in range(10000):
+        total += GLOBAL_VALUE
+    return total
+
+def use_local():
+    """Use local variable."""
+    local_value = 100
+    total = 0
+    for i in range(10000):
+        total += local_value
+    return total
+
+# Local is faster
+global_time = timeit.timeit(use_global, number=1000)
+local_time = timeit.timeit(use_local, number=1000)
+
+print(f"Global access: {global_time:.4f}s")
+print(f"Local access: {local_time:.4f}s")
+print(f"Speedup: {global_time/local_time:.2f}x")
+```
+
+### Pattern 10: Function Call Overhead
+
+```python
+import timeit
+
+def calculate_inline():
+    """Inline calculation."""
+    total = 0
+    for i in range(10000):
+        total += i * 2 + 1
+    return total
+
+def helper_function(x):
+    """Helper function."""
+    return x * 2 + 1
+
+def calculate_with_function():
+    """Calculation with function calls."""
+    total = 0
+    for i in range(10000):
+        total += helper_function(i)
+    return total
+
+# Inline is faster due to no call overhead
+inline_time = timeit.timeit(calculate_inline, number=1000)
+function_time = timeit.timeit(calculate_with_function, number=1000)
+
+print(f"Inline: {inline_time:.4f}s")
+print(f"Function calls: {function_time:.4f}s")
+```
+
+For advanced optimization techniques including NumPy vectorization, caching, memory management, parallelization, async I/O, database optimization, and benchmarking tools, see [references/advanced-patterns.md](references/advanced-patterns.md)
+
+## Best Practices
+
+1. **Profile before optimizing** - Measure to find real bottlenecks
+2. **Focus on hot paths** - Optimize code that runs most frequently
+3. **Use appropriate data structures** - Dict for lookups, set for membership
+4. **Avoid premature optimization** - Clarity first, then optimize
+5. **Use built-in functions** - They're implemented in C
+6. **Cache expensive computations** - Use lru_cache
+7. **Batch I/O operations** - Reduce system calls
+8. **Use generators** for large datasets
+9. **Consider NumPy** for numerical operations
+10. **Profile production code** - Use py-spy for live systems
+
+## Common Pitfalls
+
+- Optimizing without profiling
+- Using global variables unnecessarily
+- Not using appropriate data structures
+- Creating unnecessary copies of data
+- Not using connection pooling for databases
+- Ignoring algorithmic complexity
+- Over-optimizing rare code paths
+- Not considering memory usage

--- a/.agents/skills/python-performance-optimization/references/advanced-patterns.md
+++ b/.agents/skills/python-performance-optimization/references/advanced-patterns.md
@@ -1,0 +1,419 @@
+# Python Performance Optimization — Advanced Reference
+
+Advanced optimization techniques including NumPy vectorization, caching, memory management, parallelization, async I/O, database optimization, and benchmarking tools.
+
+## Advanced Optimization
+
+### Pattern 11: NumPy for Numerical Operations
+
+```python
+import timeit
+import numpy as np
+
+def python_sum(n):
+    """Sum using pure Python."""
+    return sum(range(n))
+
+def numpy_sum(n):
+    """Sum using NumPy."""
+    return np.arange(n).sum()
+
+n = 1000000
+
+python_time = timeit.timeit(lambda: python_sum(n), number=100)
+numpy_time = timeit.timeit(lambda: numpy_sum(n), number=100)
+
+print(f"Python: {python_time:.4f}s")
+print(f"NumPy: {numpy_time:.4f}s")
+print(f"Speedup: {python_time/numpy_time:.2f}x")
+
+# Vectorized operations
+def python_multiply():
+    """Element-wise multiplication in Python."""
+    a = list(range(100000))
+    b = list(range(100000))
+    return [x * y for x, y in zip(a, b)]
+
+def numpy_multiply():
+    """Vectorized multiplication in NumPy."""
+    a = np.arange(100000)
+    b = np.arange(100000)
+    return a * b
+
+py_time = timeit.timeit(python_multiply, number=100)
+np_time = timeit.timeit(numpy_multiply, number=100)
+
+print(f"\nPython multiply: {py_time:.4f}s")
+print(f"NumPy multiply: {np_time:.4f}s")
+print(f"Speedup: {py_time/np_time:.2f}x")
+```
+
+### Pattern 12: Caching with functools.lru_cache
+
+```python
+from functools import lru_cache
+import timeit
+
+def fibonacci_slow(n):
+    """Recursive fibonacci without caching."""
+    if n < 2:
+        return n
+    return fibonacci_slow(n-1) + fibonacci_slow(n-2)
+
+@lru_cache(maxsize=None)
+def fibonacci_fast(n):
+    """Recursive fibonacci with caching."""
+    if n < 2:
+        return n
+    return fibonacci_fast(n-1) + fibonacci_fast(n-2)
+
+# Massive speedup for recursive algorithms
+n = 30
+
+slow_time = timeit.timeit(lambda: fibonacci_slow(n), number=1)
+fast_time = timeit.timeit(lambda: fibonacci_fast(n), number=1000)
+
+print(f"Without cache (1 run): {slow_time:.4f}s")
+print(f"With cache (1000 runs): {fast_time:.4f}s")
+
+# Cache info
+print(f"Cache info: {fibonacci_fast.cache_info()}")
+```
+
+### Pattern 13: Using __slots__ for Memory
+
+```python
+import sys
+
+class RegularClass:
+    """Regular class with __dict__."""
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+class SlottedClass:
+    """Class with __slots__ for memory efficiency."""
+    __slots__ = ['x', 'y', 'z']
+
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+# Memory comparison
+regular = RegularClass(1, 2, 3)
+slotted = SlottedClass(1, 2, 3)
+
+print(f"Regular class size: {sys.getsizeof(regular)} bytes")
+print(f"Slotted class size: {sys.getsizeof(slotted)} bytes")
+
+# Significant savings with many instances
+regular_objects = [RegularClass(i, i+1, i+2) for i in range(10000)]
+slotted_objects = [SlottedClass(i, i+1, i+2) for i in range(10000)]
+
+print(f"\nMemory for 10000 regular objects: ~{sys.getsizeof(regular) * 10000} bytes")
+print(f"Memory for 10000 slotted objects: ~{sys.getsizeof(slotted) * 10000} bytes")
+```
+
+### Pattern 14: Multiprocessing for CPU-Bound Tasks
+
+```python
+import multiprocessing as mp
+import time
+
+def cpu_intensive_task(n):
+    """CPU-intensive calculation."""
+    return sum(i**2 for i in range(n))
+
+def sequential_processing():
+    """Process tasks sequentially."""
+    start = time.time()
+    results = [cpu_intensive_task(1000000) for _ in range(4)]
+    elapsed = time.time() - start
+    return elapsed, results
+
+def parallel_processing():
+    """Process tasks in parallel."""
+    start = time.time()
+    with mp.Pool(processes=4) as pool:
+        results = pool.map(cpu_intensive_task, [1000000] * 4)
+    elapsed = time.time() - start
+    return elapsed, results
+
+if __name__ == "__main__":
+    seq_time, seq_results = sequential_processing()
+    par_time, par_results = parallel_processing()
+
+    print(f"Sequential: {seq_time:.2f}s")
+    print(f"Parallel: {par_time:.2f}s")
+    print(f"Speedup: {seq_time/par_time:.2f}x")
+```
+
+### Pattern 15: Async I/O for I/O-Bound Tasks
+
+```python
+import asyncio
+import aiohttp
+import time
+import requests
+
+urls = [
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+]
+
+def synchronous_requests():
+    """Synchronous HTTP requests."""
+    start = time.time()
+    results = []
+    for url in urls:
+        response = requests.get(url)
+        results.append(response.status_code)
+    elapsed = time.time() - start
+    return elapsed, results
+
+async def async_fetch(session, url):
+    """Async HTTP request."""
+    async with session.get(url) as response:
+        return response.status
+
+async def asynchronous_requests():
+    """Asynchronous HTTP requests."""
+    start = time.time()
+    async with aiohttp.ClientSession() as session:
+        tasks = [async_fetch(session, url) for url in urls]
+        results = await asyncio.gather(*tasks)
+    elapsed = time.time() - start
+    return elapsed, results
+
+# Async is much faster for I/O-bound work
+sync_time, sync_results = synchronous_requests()
+async_time, async_results = asyncio.run(asynchronous_requests())
+
+print(f"Synchronous: {sync_time:.2f}s")
+print(f"Asynchronous: {async_time:.2f}s")
+print(f"Speedup: {sync_time/async_time:.2f}x")
+```
+
+## Database Optimization
+
+### Pattern 16: Batch Database Operations
+
+```python
+import sqlite3
+import time
+
+def create_db():
+    """Create test database."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+    return conn
+
+def slow_inserts(conn, count):
+    """Insert records one at a time."""
+    start = time.time()
+    cursor = conn.cursor()
+    for i in range(count):
+        cursor.execute("INSERT INTO users (name) VALUES (?)", (f"User {i}",))
+        conn.commit()  # Commit each insert
+    elapsed = time.time() - start
+    return elapsed
+
+def fast_inserts(conn, count):
+    """Batch insert with single commit."""
+    start = time.time()
+    cursor = conn.cursor()
+    data = [(f"User {i}",) for i in range(count)]
+    cursor.executemany("INSERT INTO users (name) VALUES (?)", data)
+    conn.commit()  # Single commit
+    elapsed = time.time() - start
+    return elapsed
+
+# Benchmark
+conn1 = create_db()
+slow_time = slow_inserts(conn1, 1000)
+
+conn2 = create_db()
+fast_time = fast_inserts(conn2, 1000)
+
+print(f"Individual inserts: {slow_time:.4f}s")
+print(f"Batch insert: {fast_time:.4f}s")
+print(f"Speedup: {slow_time/fast_time:.2f}x")
+```
+
+### Pattern 17: Query Optimization
+
+```python
+# Use indexes for frequently queried columns
+"""
+-- Slow: No index
+SELECT * FROM users WHERE email = 'user@example.com';
+
+-- Fast: With index
+CREATE INDEX idx_users_email ON users(email);
+SELECT * FROM users WHERE email = 'user@example.com';
+"""
+
+# Use query planning
+import sqlite3
+
+conn = sqlite3.connect("example.db")
+cursor = conn.cursor()
+
+# Analyze query performance
+cursor.execute("EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?", ("test@example.com",))
+print(cursor.fetchall())
+
+# Use SELECT only needed columns
+# Slow: SELECT *
+# Fast: SELECT id, name
+```
+
+## Memory Optimization
+
+### Pattern 18: Detecting Memory Leaks
+
+```python
+import tracemalloc
+import gc
+
+def memory_leak_example():
+    """Example that leaks memory."""
+    leaked_objects = []
+
+    for i in range(100000):
+        # Objects added but never removed
+        leaked_objects.append([i] * 100)
+
+    # In real code, this would be an unintended reference
+
+def track_memory_usage():
+    """Track memory allocations."""
+    tracemalloc.start()
+
+    # Take snapshot before
+    snapshot1 = tracemalloc.take_snapshot()
+
+    # Run code
+    memory_leak_example()
+
+    # Take snapshot after
+    snapshot2 = tracemalloc.take_snapshot()
+
+    # Compare
+    top_stats = snapshot2.compare_to(snapshot1, 'lineno')
+
+    print("Top 10 memory allocations:")
+    for stat in top_stats[:10]:
+        print(stat)
+
+    tracemalloc.stop()
+
+# Monitor memory
+track_memory_usage()
+
+# Force garbage collection
+gc.collect()
+```
+
+### Pattern 19: Iterators vs Lists
+
+```python
+import sys
+
+def process_file_list(filename):
+    """Load entire file into memory."""
+    with open(filename) as f:
+        lines = f.readlines()  # Loads all lines
+        return sum(1 for line in lines if line.strip())
+
+def process_file_iterator(filename):
+    """Process file line by line."""
+    with open(filename) as f:
+        return sum(1 for line in f if line.strip())
+
+# Iterator uses constant memory
+# List loads entire file into memory
+```
+
+### Pattern 20: Weakref for Caches
+
+```python
+import weakref
+
+class CachedResource:
+    """Resource that can be garbage collected."""
+    def __init__(self, data):
+        self.data = data
+
+# Regular cache prevents garbage collection
+regular_cache = {}
+
+def get_resource_regular(key):
+    """Get resource from regular cache."""
+    if key not in regular_cache:
+        regular_cache[key] = CachedResource(f"Data for {key}")
+    return regular_cache[key]
+
+# Weak reference cache allows garbage collection
+weak_cache = weakref.WeakValueDictionary()
+
+def get_resource_weak(key):
+    """Get resource from weak cache."""
+    resource = weak_cache.get(key)
+    if resource is None:
+        resource = CachedResource(f"Data for {key}")
+        weak_cache[key] = resource
+    return resource
+
+# When no strong references exist, objects can be GC'd
+```
+
+## Benchmarking Tools
+
+### Custom Benchmark Decorator
+
+```python
+import time
+from functools import wraps
+
+def benchmark(func):
+    """Decorator to benchmark function execution."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - start
+        print(f"{func.__name__} took {elapsed:.6f} seconds")
+        return result
+    return wrapper
+
+@benchmark
+def slow_function():
+    """Function to benchmark."""
+    time.sleep(0.5)
+    return sum(range(1000000))
+
+result = slow_function()
+```
+
+### Performance Testing with pytest-benchmark
+
+```python
+# Install: pip install pytest-benchmark
+
+def test_list_comprehension(benchmark):
+    """Benchmark list comprehension."""
+    result = benchmark(lambda: [i**2 for i in range(10000)])
+    assert len(result) == 10000
+
+def test_map_function(benchmark):
+    """Benchmark map function."""
+    result = benchmark(lambda: list(map(lambda x: x**2, range(10000))))
+    assert len(result) == 10000
+
+# Run with: pytest test_performance.py --benchmark-compare
+```

--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,0 +1,62 @@
+# Skill Registry — claude-code-telegram
+
+Generated: 2026-04-10
+Project: claude-code-telegram
+
+---
+
+## Project-level Skills
+
+Installed in `.claude/skills/` — scoped to this project.
+
+| Skill | Path | Triggers |
+|-------|------|----------|
+| `git-paul` | `.claude/skills/git-paul/SKILL.md` | Commits, branches, PRs, code review with Git/GitHub. Gitmoji, PascalCase branches, NO Co-Authored-By Claude. |
+| `fastapi` | `.claude/skills/fastapi/SKILL.md` | Working in `src/api/` — FastAPI best practices, Pydantic models, updated patterns. |
+| `python-performance-optimization` | `.claude/skills/python-performance-optimization/SKILL.md` | Debugging slow Python code, cProfile, memory profilers, optimizing bottlenecks. |
+
+---
+
+## User-level Skills
+
+Installed in `~/.claude/skills/` — available across all projects.
+
+| Skill | Path | Triggers |
+|-------|------|----------|
+| `sdd-init` | `~/.claude/skills/sdd-init/SKILL.md` | Initialize SDD context in a project. "sdd init", "iniciar sdd", "openspec init". |
+| `sdd-explore` | `~/.claude/skills/sdd-explore/SKILL.md` | Explore and investigate ideas before committing to a change. Orchestrator launches for investigation. |
+| `sdd-propose` | `~/.claude/skills/sdd-propose/SKILL.md` | Create a change proposal with intent, scope, and approach. Orchestrator launches for proposals. |
+| `sdd-spec` | `~/.claude/skills/sdd-spec/SKILL.md` | Write specifications with requirements and scenarios (delta specs). Orchestrator launches for specs. |
+| `sdd-design` | `~/.claude/skills/sdd-design/SKILL.md` | Create technical design document with architecture decisions. Orchestrator launches for design. |
+| `sdd-tasks` | `~/.claude/skills/sdd-tasks/SKILL.md` | Break down a change into an implementation task checklist. Orchestrator launches for task breakdown. |
+| `sdd-apply` | `~/.claude/skills/sdd-apply/SKILL.md` | Implement tasks from the change, writing actual code. Orchestrator launches for implementation. |
+| `sdd-verify` | `~/.claude/skills/sdd-verify/SKILL.md` | Validate implementation matches specs, design, and tasks. Orchestrator launches for verification. |
+| `sdd-archive` | `~/.claude/skills/sdd-archive/SKILL.md` | Sync delta specs to main specs and archive completed change. Orchestrator launches after verification. |
+| `skill-creator` | `~/.claude/skills/skill-creator/SKILL.md` | Create new AI agent skills. When user asks to create a skill or document patterns for AI. |
+| `go-testing` | `~/.claude/skills/go-testing/SKILL.md` | Go testing patterns (Gentleman.Dots). When writing Go tests, using teatest, or adding test coverage. |
+
+---
+
+## SDD DAG
+
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+             ^
+             |
+           design
+```
+
+## Engram Topic Keys
+
+| Artifact | Topic Key |
+|----------|-----------|
+| Project context | `sdd-init/claude-code-telegram` |
+| Skill registry | `skill-registry` |
+| Exploration | `sdd/{change-name}/explore` |
+| Proposal | `sdd/{change-name}/proposal` |
+| Spec | `sdd/{change-name}/spec` |
+| Design | `sdd/{change-name}/design` |
+| Tasks | `sdd/{change-name}/tasks` |
+| Apply progress | `sdd/{change-name}/apply-progress` |
+| Verify report | `sdd/{change-name}/verify-report` |
+| Archive report | `sdd/{change-name}/archive-report` |

--- a/.claude/skills/fastapi/SKILL.md
+++ b/.claude/skills/fastapi/SKILL.md
@@ -1,0 +1,436 @@
+---
+name: fastapi
+description: FastAPI best practices and conventions. Use when working with FastAPI APIs and Pydantic models for them. Keeps FastAPI code clean and up to date with the latest features and patterns, updated with new versions. Write new code or refactor and update old code.
+---
+
+# FastAPI
+
+Official FastAPI skill to write code with best practices, keeping up to date with new versions and features.
+
+## Use the `fastapi` CLI
+
+Run the development server on localhost with reload:
+
+```bash
+fastapi dev
+```
+
+
+Run the production server:
+
+```bash
+fastapi run
+```
+
+### Add an entrypoint in `pyproject.toml`
+
+FastAPI CLI will read the entrypoint in `pyproject.toml` to know where the FastAPI app is declared.
+
+```toml
+[tool.fastapi]
+entrypoint = "my_app.main:app"
+```
+
+### Use `fastapi` with a path
+
+When adding the entrypoint to `pyproject.toml` is not possible, or the user explicitly asks not to, or it's running an independent small app, you can pass the app file path to the `fastapi` command:
+
+```bash
+fastapi dev my_app/main.py
+```
+
+Prefer to set the entrypoint in `pyproject.toml` when possible.
+
+## Use `Annotated`
+
+Always prefer the `Annotated` style for parameter and dependency declarations.
+
+It keeps the function signatures working in other contexts, respects the types, allows reusability.
+
+### In Parameter Declarations
+
+Use `Annotated` for parameter declarations, including `Path`, `Query`, `Header`, etc.:
+
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, Path, Query
+
+app = FastAPI()
+
+
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: Annotated[int, Path(ge=1, description="The item ID")],
+    q: Annotated[str | None, Query(max_length=50)] = None,
+):
+    return {"message": "Hello World"}
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: int = Path(ge=1, description="The item ID"),
+    q: str | None = Query(default=None, max_length=50),
+):
+    return {"message": "Hello World"}
+```
+
+### For Dependencies
+
+Use `Annotated` for dependencies with `Depends()`.
+
+Unless asked not to, create a new type alias for the dependency to allow re-using it.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_current_user():
+    return {"username": "johndoe"}
+
+
+CurrentUserDep = Annotated[dict, Depends(get_current_user)]
+
+
+@app.get("/items/")
+async def read_item(current_user: CurrentUserDep):
+    return {"message": "Hello World"}
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+@app.get("/items/")
+async def read_item(current_user: dict = Depends(get_current_user)):
+    return {"message": "Hello World"}
+```
+
+## Do not use Ellipsis for *path operations* or Pydantic models
+
+Do not use `...` as a default value for required parameters, it's not needed and not recommended.
+
+Do this, without Ellipsis (`...`):
+
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, Query
+from pydantic import BaseModel, Field
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+    price: float = Field(gt=0)
+
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(item: Item, project_id: Annotated[int, Query()]): ...
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+class Item(BaseModel):
+    name: str = ...
+    description: str | None = None
+    price: float = Field(..., gt=0)
+
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(item: Item, project_id: Annotated[int, Query(...)]): ...
+```
+
+## Return Type or Response Model
+
+When possible, include a return type. It will be used to validate, filter, document, and serialize the response.
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me")
+async def get_item() -> Item:
+    return Item(name="Plumbus", description="All-purpose home device")
+```
+
+**Important**: Return types or response models are what filter data ensuring no sensitive information is exposed. And they are used to serialize data with Pydantic (in Rust), this is the main idea that can increase response performance.
+
+The return type doesn't have to be a Pydantic model, it could be a different type, like a list of integers, or a dict, etc.
+
+### When to use `response_model` instead
+
+If the return type is not the same as the type that you want to use to validate, filter, or serialize, use the `response_model` parameter on the decorator instead.
+
+```python
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me", response_model=Item)
+async def get_item() -> Any:
+    return {"name": "Foo", "description": "A very nice Item"}
+```
+
+This can be particularly useful when filtering data to expose only the public fields and avoid exposing sensitive information.
+
+```python
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class InternalItem(BaseModel):
+    name: str
+    description: str | None = None
+    secret_key: str
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me", response_model=Item)
+async def get_item() -> Any:
+    item = InternalItem(
+        name="Foo", description="A very nice Item", secret_key="supersecret"
+    )
+    return item
+```
+
+## Performance
+
+Do not use `ORJSONResponse` or `UJSONResponse`, they are deprecated.
+
+Instead, declare a return type or response model. Pydantic will handle the data serialization on the Rust side.
+
+## Including Routers
+
+When declaring routers, prefer to add router level parameters like prefix, tags, etc. to the router itself, instead of in `include_router()`.
+
+Do this:
+
+```python
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+router = APIRouter(prefix="/items", tags=["items"])
+
+
+@router.get("/")
+async def list_items():
+    return []
+
+
+# In main.py
+app.include_router(router)
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_items():
+    return []
+
+
+# In main.py
+app.include_router(router, prefix="/items", tags=["items"])
+```
+
+There could be exceptions, but try to follow this convention.
+
+Apply shared dependencies at the router level via `dependencies=[Depends(...)]`.
+
+## Dependency Injection
+
+See [the dependency injection reference](references/dependencies.md) for detailed patterns including `yield` with `scope`, and class dependencies.
+
+Use dependencies when the logic can't be declared in Pydantic validation, depends on external resources, needs cleanup (with `yield`), or is shared across endpoints.
+
+Apply shared dependencies at the router level via `dependencies=[Depends(...)]`.
+
+## Async vs Sync *path operations*
+
+Use `async` *path operations* only when fully certain that the logic called inside is compatible with async and await (it's called with `await`) or that doesn't block.
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+# Use async def when calling async code
+@app.get("/async-items/")
+async def read_async_items():
+    data = await some_async_library.fetch_items()
+    return data
+
+
+# Use plain def when calling blocking/sync code or when in doubt
+@app.get("/items/")
+def read_items():
+    data = some_blocking_library.fetch_items()
+    return data
+```
+
+In case of doubt, or by default, use regular `def` functions, those will be run in a threadpool so they don't block the event loop.
+
+The same rules apply to dependencies.
+
+Make sure blocking code is not run inside of `async` functions. The logic will work, but will damage the performance heavily.
+
+When needing to mix blocking and async code, see Asyncer in [the other tools reference](references/other-tools.md).
+
+## Streaming (JSON Lines, SSE, bytes)
+
+See [the streaming reference](references/streaming.md) for JSON Lines, Server-Sent Events (`EventSourceResponse`, `ServerSentEvent`), and byte streaming (`StreamingResponse`) patterns.
+
+## Tooling
+
+See [the other tools reference](references/other-tools.md) for details on uv, Ruff, ty for package management, linting, type checking, formatting, etc.
+
+## Other Libraries
+
+See [the other tools reference](references/other-tools.md) for details on other libraries:
+
+* Asyncer for handling async and await, concurrency, mixing async and blocking code, prefer it over AnyIO or asyncio.
+* SQLModel for working with SQL databases, prefer it over SQLAlchemy.
+* HTTPX for interacting with HTTP (other APIs), prefer it over Requests.
+
+## Do not use Pydantic RootModels
+
+Do not use Pydantic `RootModel`, instead use regular type annotations with `Annotated` and Pydantic validation utilities.
+
+For example, for a list with validations you could do:
+
+```python
+from typing import Annotated
+
+from fastapi import Body, FastAPI
+from pydantic import Field
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_items(items: Annotated[list[int], Field(min_length=1), Body()]):
+    return items
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+from typing import Annotated
+
+from fastapi import FastAPI
+from pydantic import Field, RootModel
+
+app = FastAPI()
+
+
+class ItemList(RootModel[Annotated[list[int], Field(min_length=1)]]):
+    pass
+
+
+@app.post("/items/")
+async def create_items(items: ItemList):
+    return items
+
+```
+
+FastAPI supports these type annotations and will create a Pydantic `TypeAdapter` for them, so that types can work as normally and there's no need for the custom logic and types in RootModels.
+
+## Use one HTTP operation per function
+
+Don't mix HTTP operations in a single function, having one function per HTTP operation helps separate concerns and organize the code.
+
+Do this:
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+
+
+@app.get("/items/")
+async def list_items():
+    return []
+
+
+@app.post("/items/")
+async def create_item(item: Item):
+    return item
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+
+
+@app.api_route("/items/", methods=["GET", "POST"])
+async def handle_items(request: Request):
+    if request.method == "GET":
+        return []
+```

--- a/.claude/skills/fastapi/references/dependencies.md
+++ b/.claude/skills/fastapi/references/dependencies.md
@@ -1,0 +1,142 @@
+# Dependency Injection
+
+Use dependencies when:
+
+* They can't be declared in Pydantic validation and require additional logic
+* The logic depends on external resources or could block in any other way
+* Other dependencies need their results (it's a sub-dependency)
+* The logic can be shared by multiple endpoints to do things like error early, authentication, etc.
+* They need to handle cleanup (e.g., DB sessions, file handles), using dependencies with `yield`
+* Their logic needs input data from the request, like headers, query parameters, etc.
+
+## Dependencies with `yield` and `scope`
+
+When using dependencies with `yield`, they can have a `scope` that defines when the exit code is run.
+
+Use the default scope `"request"` to run the exit code after the response is sent back.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_db():
+    db = DBSession()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+DBDep = Annotated[DBSession, Depends(get_db)]
+
+
+@app.get("/items/")
+async def read_items(db: DBDep):
+    return db.query(Item).all()
+```
+
+Use the scope `"function"` when they should run the exit code after the response data is generated but before the response is sent back to the client.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_username():
+    try:
+        yield "Rick"
+    finally:
+        print("Cleanup up before response is sent")
+
+UserNameDep = Annotated[str, Depends(get_username, scope="function")]
+
+@app.get("/users/me")
+def get_user_me(username: UserNameDep):
+    return username
+```
+
+## Class Dependencies
+
+Avoid creating class dependencies when possible.
+
+If a class is needed, instead create a regular function dependency that returns a class instance.
+
+Do this:
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+@dataclass
+class DatabasePaginator:
+    offset: int = 0
+    limit: int = 100
+    q: str | None = None
+
+    def get_page(self) -> dict:
+        # Simulate a page of data
+        return {
+            "offset": self.offset,
+            "limit": self.limit,
+            "q": self.q,
+            "items": [],
+        }
+
+
+def get_db_paginator(
+    offset: int = 0, limit: int = 100, q: str | None = None
+) -> DatabasePaginator:
+    return DatabasePaginator(offset=offset, limit=limit, q=q)
+
+
+PaginatorDep = Annotated[DatabasePaginator, Depends(get_db_paginator)]
+
+
+@app.get("/items/")
+async def read_items(paginator: PaginatorDep):
+    return paginator.get_page()
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+class DatabasePaginator:
+    def __init__(self, offset: int = 0, limit: int = 100, q: str | None = None):
+        self.offset = offset
+        self.limit = limit
+        self.q = q
+
+    def get_page(self) -> dict:
+        # Simulate a page of data
+        return {
+            "offset": self.offset,
+            "limit": self.limit,
+            "q": self.q,
+            "items": [],
+        }
+
+
+@app.get("/items/")
+async def read_items(paginator: Annotated[DatabasePaginator, Depends()]):
+    return paginator.get_page()
+```

--- a/.claude/skills/fastapi/references/other-tools.md
+++ b/.claude/skills/fastapi/references/other-tools.md
@@ -1,0 +1,76 @@
+# Other Tools
+
+## uv
+
+If uv is available, use it to manage dependencies.
+
+## Ruff
+
+If Ruff is available, use it to lint and format the code. Consider enabling the FastAPI rules.
+
+## ty
+
+If ty is available, use it to check types.
+
+## Asyncer
+
+When needing to run blocking code inside of async functions, or async code inside of blocking functions, suggest using Asyncer.
+
+Prefer it over AnyIO or asyncio.
+
+Install:
+
+```bash
+uv add asyncer
+```
+
+Run blocking sync code inside of async with `asyncify()`:
+
+```python
+from asyncer import asyncify
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+def do_blocking_work(name: str) -> str:
+    # Some blocking I/O operation
+    return f"Hello {name}"
+
+
+@app.get("/items/")
+async def read_items():
+    result = await asyncify(do_blocking_work)(name="World")
+    return {"message": result}
+```
+
+And run async code inside of blocking sync code with `syncify()`:
+
+```python
+from asyncer import syncify
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+async def do_async_work(name: str) -> str:
+    return f"Hello {name}"
+
+
+@app.get("/items/")
+def read_items():
+    result = syncify(do_async_work)(name="World")
+    return {"message": result}
+```
+
+## SQLModel for SQL databases
+
+When working with SQL databases, prefer using SQLModel as it is integrated with Pydantic and will allow declaring data validation with the same models.
+
+Prefer it over SQLAlchemy.
+
+## HTTPX
+
+Use HTTPX for handling HTTP communication (e.g. with other APIs). It support sync and async usage.
+
+Prefer it over Requests.

--- a/.claude/skills/fastapi/references/streaming.md
+++ b/.claude/skills/fastapi/references/streaming.md
@@ -1,0 +1,105 @@
+# Streaming
+
+## Stream JSON Lines
+
+To stream JSON Lines, declare the return type and use `yield` to return the data.
+
+```python
+@app.get("/items/stream")
+async def stream_items() -> AsyncIterable[Item]:
+    for item in items:
+        yield item
+```
+
+## Server-Sent Events (SSE)
+
+To stream Server-Sent Events, use `response_class=EventSourceResponse` and `yield` items from the endpoint.
+
+Plain objects are automatically JSON-serialized as `data:` fields, declare the return type so the serialization is done by Pydantic:
+
+```python
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+@app.get("/items/stream", response_class=EventSourceResponse)
+async def stream_items() -> AsyncIterable[Item]:
+    yield Item(name="Plumbus", price=32.99)
+    yield Item(name="Portal Gun", price=999.99)
+```
+
+For full control over SSE fields (`event`, `id`, `retry`, `comment`), yield `ServerSentEvent` instances:
+
+```python
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+
+app = FastAPI()
+
+
+@app.get("/events", response_class=EventSourceResponse)
+async def stream_events() -> AsyncIterable[ServerSentEvent]:
+    yield ServerSentEvent(data={"status": "started"}, event="status", id="1")
+    yield ServerSentEvent(data={"progress": 50}, event="progress", id="2")
+```
+
+Use `raw_data` instead of `data` to send pre-formatted strings without JSON encoding:
+
+```python
+yield ServerSentEvent(raw_data="plain text line", event="log")
+```
+
+## Stream bytes
+
+To stream bytes, declare a `response_class=` of `StreamingResponse` or a sub-class, and use `yield` to return the data.
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.utils import read_image
+
+app = FastAPI()
+
+
+class PNGStreamingResponse(StreamingResponse):
+    media_type = "image/png"
+
+@app.get("/image", response_class=PNGStreamingResponse)
+def stream_image_no_async_no_annotation():
+    with read_image() as image_file:
+        yield from image_file
+```
+
+prefer this over returning a `StreamingResponse` directly:
+
+```python
+# DO NOT DO THIS
+
+import anyio
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.utils import read_image
+
+app = FastAPI()
+
+
+class PNGStreamingResponse(StreamingResponse):
+    media_type = "image/png"
+
+
+@app.get("/")
+async def main():
+    return PNGStreamingResponse(read_image())
+```

--- a/.claude/skills/git-paul/SKILL.md
+++ b/.claude/skills/git-paul/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: git-paul
+description: Git workflow assistant for Paul Osinga — commits con Gitmoji, PRs en GitHub, branches en PascalCase y code review. Usa este skill cuando el usuario pida hacer commits, crear branches, abrir PRs, o revisar código con Git/GitHub. NUNCA incluir a Claude como co-autor.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# Git Workflow — Paul Osinga
+
+Eres el asistente de Git de Paul. Manejas commits, PRs, branches y code review en GitHub.
+
+## REGLAS ABSOLUTAS
+
+1. **NUNCA** agregar `Co-Authored-By: Claude` ni ninguna mención a Claude/Anthropic en commits, PRs, títulos, descripciones ni mensajes.
+2. **NUNCA** usar `--no-verify` ni saltarte hooks.
+3. **NUNCA** hacer force push a `main` o `master`.
+4. Siempre usar `gh` CLI para operaciones de GitHub.
+5. Stagear archivos específicos — nunca `git add -A` sin revisar primero.
+
+---
+
+## Commits
+
+### Formato
+
+```
+<gitmoji> <tipo>(<scope opcional>): <descripción corta en imperativo>
+
+<cuerpo opcional>
+```
+
+### Tabla de Gitmoji
+
+| Emoji | Código | Cuándo |
+|-------|--------|--------|
+| ✨ | `:sparkles:` | Nueva funcionalidad |
+| 🐛 | `:bug:` | Fix de bug |
+| 🚑️ | `:ambulance:` | Fix crítico / hotfix |
+| 🎨 | `:art:` | Mejorar estructura/formato |
+| ⚡️ | `:zap:` | Mejora de rendimiento |
+| 📝 | `:memo:` | Documentación |
+| 🔧 | `:wrench:` | Config / archivos de configuración |
+| ♻️ | `:recycle:` | Refactor |
+| 🗑️ | `:wastebasket:` | Eliminar código/archivos |
+| 🚚 | `:truck:` | Mover/renombrar archivos |
+| 🔒️ | `:lock:` | Fix de seguridad |
+| ⬆️ | `:arrow_up:` | Actualizar dependencias |
+| 🏗️ | `:building_construction:` | Cambios arquitectónicos |
+| 🚀 | `:rocket:` | Deploy/release |
+| ✅ | `:white_check_mark:` | Tests |
+| 🔥 | `:fire:` | Eliminar código muerto |
+| 💄 | `:lipstick:` | UI/estilos |
+| 🌐 | `:globe_with_meridians:` | i18n/l10n |
+| 🐳 | `:whale:` | Docker |
+
+### Cómo hacer un commit
+
+1. Revisar `git status` y `git diff` para entender los cambios.
+2. Elegir el gitmoji correcto según el tipo de cambio.
+3. Stagear solo los archivos relevantes.
+4. Escribir el mensaje en imperativo, en español o inglés según el proyecto.
+
+```bash
+git add <archivos específicos>
+git commit -m "$(cat <<'EOF'
+✨ feat(notifications): agregar guard wasRecentlyCreated en discover_notification
+EOF
+)"
+```
+
+---
+
+## Branches
+
+### Nomenclatura — PascalCase, sin guiones ni underscores
+
+```
+<Tipo>/<DescripcionEnPascalCase>
+```
+
+| Tipo | Cuándo |
+|------|--------|
+| `Feat/` | Nueva funcionalidad |
+| `Fix/` | Bug fix |
+| `Hotfix/` | Fix urgente en producción |
+| `Refactor/` | Refactor sin cambio funcional |
+| `Chore/` | Mantenimiento, config, deps |
+| `Docs/` | Solo documentación |
+
+**Ejemplos:**
+- `Feat/DiscoverNotificationLaravel`
+- `Fix/DuplicateFcmNotification`
+- `Hotfix/CriticalAuthError`
+- `Chore/K8sCronjobCleanup`
+
+```bash
+git checkout -b Feat/NombreDescriptivo
+git push -u origin Feat/NombreDescriptivo
+```
+
+---
+
+## Pull Requests
+
+### Título — con Gitmoji
+
+```
+✨ feat: descripción concisa del cambio
+```
+
+### Cuerpo
+
+```markdown
+## Que hace este PR?
+<1-3 bullets concisos>
+
+## Por que?
+<contexto y motivacion>
+
+## Como probarlo?
+- [ ] paso 1
+- [ ] paso 2
+```
+
+### Crear PR con gh
+
+```bash
+gh pr create \
+  --title "✨ feat: descripción" \
+  --body "$(cat <<'EOF'
+## Que hace este PR?
+- ...
+
+## Por que?
+...
+
+## Como probarlo?
+- [ ] ...
+EOF
+)"
+```
+
+---
+
+## Code Review
+
+Al revisar un PR:
+
+1. `gh pr checkout <número>` para revisar localmente.
+2. `gh pr diff <número>` para ver los cambios.
+3. `gh pr view <número> --comments` para ver comentarios existentes.
+4. Comentar: `gh pr review <número> --comment -b "mensaje"`
+5. Aprobar: `gh pr review <número> --approve`
+6. Solicitar cambios: `gh pr review <número> --request-changes -b "motivo"`
+
+### Criterios de review
+
+- El cambio hace lo que dice el titulo/descripcion?
+- Hay riesgos de regresion o side effects?
+- El codigo es legible sin comentarios innecesarios?
+- Los tests cubren el caso?

--- a/.claude/skills/python-performance-optimization/SKILL.md
+++ b/.claude/skills/python-performance-optimization/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: python-performance-optimization
+description: Profile and optimize Python code using cProfile, memory profilers, and performance best practices. Use when debugging slow Python code, optimizing bottlenecks, or improving application performance.
+---
+
+# Python Performance Optimization
+
+Comprehensive guide to profiling, analyzing, and optimizing Python code for better performance, including CPU profiling, memory optimization, and implementation best practices.
+
+## When to Use This Skill
+
+- Identifying performance bottlenecks in Python applications
+- Reducing application latency and response times
+- Optimizing CPU-intensive operations
+- Reducing memory consumption and memory leaks
+- Improving database query performance
+- Optimizing I/O operations
+- Speeding up data processing pipelines
+- Implementing high-performance algorithms
+- Profiling production applications
+
+## Core Concepts
+
+### 1. Profiling Types
+
+- **CPU Profiling**: Identify time-consuming functions
+- **Memory Profiling**: Track memory allocation and leaks
+- **Line Profiling**: Profile at line-by-line granularity
+- **Call Graph**: Visualize function call relationships
+
+### 2. Performance Metrics
+
+- **Execution Time**: How long operations take
+- **Memory Usage**: Peak and average memory consumption
+- **CPU Utilization**: Processor usage patterns
+- **I/O Wait**: Time spent on I/O operations
+
+### 3. Optimization Strategies
+
+- **Algorithmic**: Better algorithms and data structures
+- **Implementation**: More efficient code patterns
+- **Parallelization**: Multi-threading/processing
+- **Caching**: Avoid redundant computation
+- **Native Extensions**: C/Rust for critical paths
+
+## Quick Start
+
+### Basic Timing
+
+```python
+import time
+
+def measure_time():
+    """Simple timing measurement."""
+    start = time.time()
+
+    # Your code here
+    result = sum(range(1000000))
+
+    elapsed = time.time() - start
+    print(f"Execution time: {elapsed:.4f} seconds")
+    return result
+
+# Better: use timeit for accurate measurements
+import timeit
+
+execution_time = timeit.timeit(
+    "sum(range(1000000))",
+    number=100
+)
+print(f"Average time: {execution_time/100:.6f} seconds")
+```
+
+## Profiling Tools
+
+### Pattern 1: cProfile - CPU Profiling
+
+```python
+import cProfile
+import pstats
+from pstats import SortKey
+
+def slow_function():
+    """Function to profile."""
+    total = 0
+    for i in range(1000000):
+        total += i
+    return total
+
+def another_function():
+    """Another function."""
+    return [i**2 for i in range(100000)]
+
+def main():
+    """Main function to profile."""
+    result1 = slow_function()
+    result2 = another_function()
+    return result1, result2
+
+# Profile the code
+if __name__ == "__main__":
+    profiler = cProfile.Profile()
+    profiler.enable()
+
+    main()
+
+    profiler.disable()
+
+    # Print stats
+    stats = pstats.Stats(profiler)
+    stats.sort_stats(SortKey.CUMULATIVE)
+    stats.print_stats(10)  # Top 10 functions
+
+    # Save to file for later analysis
+    stats.dump_stats("profile_output.prof")
+```
+
+**Command-line profiling:**
+
+```bash
+# Profile a script
+python -m cProfile -o output.prof script.py
+
+# View results
+python -m pstats output.prof
+# In pstats:
+# sort cumtime
+# stats 10
+```
+
+### Pattern 2: line_profiler - Line-by-Line Profiling
+
+```python
+# Install: pip install line-profiler
+
+# Add @profile decorator (line_profiler provides this)
+@profile
+def process_data(data):
+    """Process data with line profiling."""
+    result = []
+    for item in data:
+        processed = item * 2
+        result.append(processed)
+    return result
+
+# Run with:
+# kernprof -l -v script.py
+```
+
+**Manual line profiling:**
+
+```python
+from line_profiler import LineProfiler
+
+def process_data(data):
+    """Function to profile."""
+    result = []
+    for item in data:
+        processed = item * 2
+        result.append(processed)
+    return result
+
+if __name__ == "__main__":
+    lp = LineProfiler()
+    lp.add_function(process_data)
+
+    data = list(range(100000))
+
+    lp_wrapper = lp(process_data)
+    lp_wrapper(data)
+
+    lp.print_stats()
+```
+
+### Pattern 3: memory_profiler - Memory Usage
+
+```python
+# Install: pip install memory-profiler
+
+from memory_profiler import profile
+
+@profile
+def memory_intensive():
+    """Function that uses lots of memory."""
+    # Create large list
+    big_list = [i for i in range(1000000)]
+
+    # Create large dict
+    big_dict = {i: i**2 for i in range(100000)}
+
+    # Process data
+    result = sum(big_list)
+
+    return result
+
+if __name__ == "__main__":
+    memory_intensive()
+
+# Run with:
+# python -m memory_profiler script.py
+```
+
+### Pattern 4: py-spy - Production Profiling
+
+```bash
+# Install: pip install py-spy
+
+# Profile a running Python process
+py-spy top --pid 12345
+
+# Generate flamegraph
+py-spy record -o profile.svg --pid 12345
+
+# Profile a script
+py-spy record -o profile.svg -- python script.py
+
+# Dump current call stack
+py-spy dump --pid 12345
+```
+
+## Optimization Patterns
+
+### Pattern 5: List Comprehensions vs Loops
+
+```python
+import timeit
+
+# Slow: Traditional loop
+def slow_squares(n):
+    """Create list of squares using loop."""
+    result = []
+    for i in range(n):
+        result.append(i**2)
+    return result
+
+# Fast: List comprehension
+def fast_squares(n):
+    """Create list of squares using comprehension."""
+    return [i**2 for i in range(n)]
+
+# Benchmark
+n = 100000
+
+slow_time = timeit.timeit(lambda: slow_squares(n), number=100)
+fast_time = timeit.timeit(lambda: fast_squares(n), number=100)
+
+print(f"Loop: {slow_time:.4f}s")
+print(f"Comprehension: {fast_time:.4f}s")
+print(f"Speedup: {slow_time/fast_time:.2f}x")
+
+# Even faster for simple operations: map
+def faster_squares(n):
+    """Use map for even better performance."""
+    return list(map(lambda x: x**2, range(n)))
+```
+
+### Pattern 6: Generator Expressions for Memory
+
+```python
+import sys
+
+def list_approach():
+    """Memory-intensive list."""
+    data = [i**2 for i in range(1000000)]
+    return sum(data)
+
+def generator_approach():
+    """Memory-efficient generator."""
+    data = (i**2 for i in range(1000000))
+    return sum(data)
+
+# Memory comparison
+list_data = [i for i in range(1000000)]
+gen_data = (i for i in range(1000000))
+
+print(f"List size: {sys.getsizeof(list_data)} bytes")
+print(f"Generator size: {sys.getsizeof(gen_data)} bytes")
+
+# Generators use constant memory regardless of size
+```
+
+### Pattern 7: String Concatenation
+
+```python
+import timeit
+
+def slow_concat(items):
+    """Slow string concatenation."""
+    result = ""
+    for item in items:
+        result += str(item)
+    return result
+
+def fast_concat(items):
+    """Fast string concatenation with join."""
+    return "".join(str(item) for item in items)
+
+def faster_concat(items):
+    """Even faster with list."""
+    parts = [str(item) for item in items]
+    return "".join(parts)
+
+items = list(range(10000))
+
+# Benchmark
+slow = timeit.timeit(lambda: slow_concat(items), number=100)
+fast = timeit.timeit(lambda: fast_concat(items), number=100)
+faster = timeit.timeit(lambda: faster_concat(items), number=100)
+
+print(f"Concatenation (+): {slow:.4f}s")
+print(f"Join (generator): {fast:.4f}s")
+print(f"Join (list): {faster:.4f}s")
+```
+
+### Pattern 8: Dictionary Lookups vs List Searches
+
+```python
+import timeit
+
+# Create test data
+size = 10000
+items = list(range(size))
+lookup_dict = {i: i for i in range(size)}
+
+def list_search(items, target):
+    """O(n) search in list."""
+    return target in items
+
+def dict_search(lookup_dict, target):
+    """O(1) search in dict."""
+    return target in lookup_dict
+
+target = size - 1  # Worst case for list
+
+# Benchmark
+list_time = timeit.timeit(
+    lambda: list_search(items, target),
+    number=1000
+)
+dict_time = timeit.timeit(
+    lambda: dict_search(lookup_dict, target),
+    number=1000
+)
+
+print(f"List search: {list_time:.6f}s")
+print(f"Dict search: {dict_time:.6f}s")
+print(f"Speedup: {list_time/dict_time:.0f}x")
+```
+
+### Pattern 9: Local Variable Access
+
+```python
+import timeit
+
+# Global variable (slow)
+GLOBAL_VALUE = 100
+
+def use_global():
+    """Access global variable."""
+    total = 0
+    for i in range(10000):
+        total += GLOBAL_VALUE
+    return total
+
+def use_local():
+    """Use local variable."""
+    local_value = 100
+    total = 0
+    for i in range(10000):
+        total += local_value
+    return total
+
+# Local is faster
+global_time = timeit.timeit(use_global, number=1000)
+local_time = timeit.timeit(use_local, number=1000)
+
+print(f"Global access: {global_time:.4f}s")
+print(f"Local access: {local_time:.4f}s")
+print(f"Speedup: {global_time/local_time:.2f}x")
+```
+
+### Pattern 10: Function Call Overhead
+
+```python
+import timeit
+
+def calculate_inline():
+    """Inline calculation."""
+    total = 0
+    for i in range(10000):
+        total += i * 2 + 1
+    return total
+
+def helper_function(x):
+    """Helper function."""
+    return x * 2 + 1
+
+def calculate_with_function():
+    """Calculation with function calls."""
+    total = 0
+    for i in range(10000):
+        total += helper_function(i)
+    return total
+
+# Inline is faster due to no call overhead
+inline_time = timeit.timeit(calculate_inline, number=1000)
+function_time = timeit.timeit(calculate_with_function, number=1000)
+
+print(f"Inline: {inline_time:.4f}s")
+print(f"Function calls: {function_time:.4f}s")
+```
+
+For advanced optimization techniques including NumPy vectorization, caching, memory management, parallelization, async I/O, database optimization, and benchmarking tools, see [references/advanced-patterns.md](references/advanced-patterns.md)
+
+## Best Practices
+
+1. **Profile before optimizing** - Measure to find real bottlenecks
+2. **Focus on hot paths** - Optimize code that runs most frequently
+3. **Use appropriate data structures** - Dict for lookups, set for membership
+4. **Avoid premature optimization** - Clarity first, then optimize
+5. **Use built-in functions** - They're implemented in C
+6. **Cache expensive computations** - Use lru_cache
+7. **Batch I/O operations** - Reduce system calls
+8. **Use generators** for large datasets
+9. **Consider NumPy** for numerical operations
+10. **Profile production code** - Use py-spy for live systems
+
+## Common Pitfalls
+
+- Optimizing without profiling
+- Using global variables unnecessarily
+- Not using appropriate data structures
+- Creating unnecessary copies of data
+- Not using connection pooling for databases
+- Ignoring algorithmic complexity
+- Over-optimizing rare code paths
+- Not considering memory usage

--- a/.claude/skills/python-performance-optimization/references/advanced-patterns.md
+++ b/.claude/skills/python-performance-optimization/references/advanced-patterns.md
@@ -1,0 +1,419 @@
+# Python Performance Optimization — Advanced Reference
+
+Advanced optimization techniques including NumPy vectorization, caching, memory management, parallelization, async I/O, database optimization, and benchmarking tools.
+
+## Advanced Optimization
+
+### Pattern 11: NumPy for Numerical Operations
+
+```python
+import timeit
+import numpy as np
+
+def python_sum(n):
+    """Sum using pure Python."""
+    return sum(range(n))
+
+def numpy_sum(n):
+    """Sum using NumPy."""
+    return np.arange(n).sum()
+
+n = 1000000
+
+python_time = timeit.timeit(lambda: python_sum(n), number=100)
+numpy_time = timeit.timeit(lambda: numpy_sum(n), number=100)
+
+print(f"Python: {python_time:.4f}s")
+print(f"NumPy: {numpy_time:.4f}s")
+print(f"Speedup: {python_time/numpy_time:.2f}x")
+
+# Vectorized operations
+def python_multiply():
+    """Element-wise multiplication in Python."""
+    a = list(range(100000))
+    b = list(range(100000))
+    return [x * y for x, y in zip(a, b)]
+
+def numpy_multiply():
+    """Vectorized multiplication in NumPy."""
+    a = np.arange(100000)
+    b = np.arange(100000)
+    return a * b
+
+py_time = timeit.timeit(python_multiply, number=100)
+np_time = timeit.timeit(numpy_multiply, number=100)
+
+print(f"\nPython multiply: {py_time:.4f}s")
+print(f"NumPy multiply: {np_time:.4f}s")
+print(f"Speedup: {py_time/np_time:.2f}x")
+```
+
+### Pattern 12: Caching with functools.lru_cache
+
+```python
+from functools import lru_cache
+import timeit
+
+def fibonacci_slow(n):
+    """Recursive fibonacci without caching."""
+    if n < 2:
+        return n
+    return fibonacci_slow(n-1) + fibonacci_slow(n-2)
+
+@lru_cache(maxsize=None)
+def fibonacci_fast(n):
+    """Recursive fibonacci with caching."""
+    if n < 2:
+        return n
+    return fibonacci_fast(n-1) + fibonacci_fast(n-2)
+
+# Massive speedup for recursive algorithms
+n = 30
+
+slow_time = timeit.timeit(lambda: fibonacci_slow(n), number=1)
+fast_time = timeit.timeit(lambda: fibonacci_fast(n), number=1000)
+
+print(f"Without cache (1 run): {slow_time:.4f}s")
+print(f"With cache (1000 runs): {fast_time:.4f}s")
+
+# Cache info
+print(f"Cache info: {fibonacci_fast.cache_info()}")
+```
+
+### Pattern 13: Using __slots__ for Memory
+
+```python
+import sys
+
+class RegularClass:
+    """Regular class with __dict__."""
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+class SlottedClass:
+    """Class with __slots__ for memory efficiency."""
+    __slots__ = ['x', 'y', 'z']
+
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+# Memory comparison
+regular = RegularClass(1, 2, 3)
+slotted = SlottedClass(1, 2, 3)
+
+print(f"Regular class size: {sys.getsizeof(regular)} bytes")
+print(f"Slotted class size: {sys.getsizeof(slotted)} bytes")
+
+# Significant savings with many instances
+regular_objects = [RegularClass(i, i+1, i+2) for i in range(10000)]
+slotted_objects = [SlottedClass(i, i+1, i+2) for i in range(10000)]
+
+print(f"\nMemory for 10000 regular objects: ~{sys.getsizeof(regular) * 10000} bytes")
+print(f"Memory for 10000 slotted objects: ~{sys.getsizeof(slotted) * 10000} bytes")
+```
+
+### Pattern 14: Multiprocessing for CPU-Bound Tasks
+
+```python
+import multiprocessing as mp
+import time
+
+def cpu_intensive_task(n):
+    """CPU-intensive calculation."""
+    return sum(i**2 for i in range(n))
+
+def sequential_processing():
+    """Process tasks sequentially."""
+    start = time.time()
+    results = [cpu_intensive_task(1000000) for _ in range(4)]
+    elapsed = time.time() - start
+    return elapsed, results
+
+def parallel_processing():
+    """Process tasks in parallel."""
+    start = time.time()
+    with mp.Pool(processes=4) as pool:
+        results = pool.map(cpu_intensive_task, [1000000] * 4)
+    elapsed = time.time() - start
+    return elapsed, results
+
+if __name__ == "__main__":
+    seq_time, seq_results = sequential_processing()
+    par_time, par_results = parallel_processing()
+
+    print(f"Sequential: {seq_time:.2f}s")
+    print(f"Parallel: {par_time:.2f}s")
+    print(f"Speedup: {seq_time/par_time:.2f}x")
+```
+
+### Pattern 15: Async I/O for I/O-Bound Tasks
+
+```python
+import asyncio
+import aiohttp
+import time
+import requests
+
+urls = [
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+]
+
+def synchronous_requests():
+    """Synchronous HTTP requests."""
+    start = time.time()
+    results = []
+    for url in urls:
+        response = requests.get(url)
+        results.append(response.status_code)
+    elapsed = time.time() - start
+    return elapsed, results
+
+async def async_fetch(session, url):
+    """Async HTTP request."""
+    async with session.get(url) as response:
+        return response.status
+
+async def asynchronous_requests():
+    """Asynchronous HTTP requests."""
+    start = time.time()
+    async with aiohttp.ClientSession() as session:
+        tasks = [async_fetch(session, url) for url in urls]
+        results = await asyncio.gather(*tasks)
+    elapsed = time.time() - start
+    return elapsed, results
+
+# Async is much faster for I/O-bound work
+sync_time, sync_results = synchronous_requests()
+async_time, async_results = asyncio.run(asynchronous_requests())
+
+print(f"Synchronous: {sync_time:.2f}s")
+print(f"Asynchronous: {async_time:.2f}s")
+print(f"Speedup: {sync_time/async_time:.2f}x")
+```
+
+## Database Optimization
+
+### Pattern 16: Batch Database Operations
+
+```python
+import sqlite3
+import time
+
+def create_db():
+    """Create test database."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+    return conn
+
+def slow_inserts(conn, count):
+    """Insert records one at a time."""
+    start = time.time()
+    cursor = conn.cursor()
+    for i in range(count):
+        cursor.execute("INSERT INTO users (name) VALUES (?)", (f"User {i}",))
+        conn.commit()  # Commit each insert
+    elapsed = time.time() - start
+    return elapsed
+
+def fast_inserts(conn, count):
+    """Batch insert with single commit."""
+    start = time.time()
+    cursor = conn.cursor()
+    data = [(f"User {i}",) for i in range(count)]
+    cursor.executemany("INSERT INTO users (name) VALUES (?)", data)
+    conn.commit()  # Single commit
+    elapsed = time.time() - start
+    return elapsed
+
+# Benchmark
+conn1 = create_db()
+slow_time = slow_inserts(conn1, 1000)
+
+conn2 = create_db()
+fast_time = fast_inserts(conn2, 1000)
+
+print(f"Individual inserts: {slow_time:.4f}s")
+print(f"Batch insert: {fast_time:.4f}s")
+print(f"Speedup: {slow_time/fast_time:.2f}x")
+```
+
+### Pattern 17: Query Optimization
+
+```python
+# Use indexes for frequently queried columns
+"""
+-- Slow: No index
+SELECT * FROM users WHERE email = 'user@example.com';
+
+-- Fast: With index
+CREATE INDEX idx_users_email ON users(email);
+SELECT * FROM users WHERE email = 'user@example.com';
+"""
+
+# Use query planning
+import sqlite3
+
+conn = sqlite3.connect("example.db")
+cursor = conn.cursor()
+
+# Analyze query performance
+cursor.execute("EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?", ("test@example.com",))
+print(cursor.fetchall())
+
+# Use SELECT only needed columns
+# Slow: SELECT *
+# Fast: SELECT id, name
+```
+
+## Memory Optimization
+
+### Pattern 18: Detecting Memory Leaks
+
+```python
+import tracemalloc
+import gc
+
+def memory_leak_example():
+    """Example that leaks memory."""
+    leaked_objects = []
+
+    for i in range(100000):
+        # Objects added but never removed
+        leaked_objects.append([i] * 100)
+
+    # In real code, this would be an unintended reference
+
+def track_memory_usage():
+    """Track memory allocations."""
+    tracemalloc.start()
+
+    # Take snapshot before
+    snapshot1 = tracemalloc.take_snapshot()
+
+    # Run code
+    memory_leak_example()
+
+    # Take snapshot after
+    snapshot2 = tracemalloc.take_snapshot()
+
+    # Compare
+    top_stats = snapshot2.compare_to(snapshot1, 'lineno')
+
+    print("Top 10 memory allocations:")
+    for stat in top_stats[:10]:
+        print(stat)
+
+    tracemalloc.stop()
+
+# Monitor memory
+track_memory_usage()
+
+# Force garbage collection
+gc.collect()
+```
+
+### Pattern 19: Iterators vs Lists
+
+```python
+import sys
+
+def process_file_list(filename):
+    """Load entire file into memory."""
+    with open(filename) as f:
+        lines = f.readlines()  # Loads all lines
+        return sum(1 for line in lines if line.strip())
+
+def process_file_iterator(filename):
+    """Process file line by line."""
+    with open(filename) as f:
+        return sum(1 for line in f if line.strip())
+
+# Iterator uses constant memory
+# List loads entire file into memory
+```
+
+### Pattern 20: Weakref for Caches
+
+```python
+import weakref
+
+class CachedResource:
+    """Resource that can be garbage collected."""
+    def __init__(self, data):
+        self.data = data
+
+# Regular cache prevents garbage collection
+regular_cache = {}
+
+def get_resource_regular(key):
+    """Get resource from regular cache."""
+    if key not in regular_cache:
+        regular_cache[key] = CachedResource(f"Data for {key}")
+    return regular_cache[key]
+
+# Weak reference cache allows garbage collection
+weak_cache = weakref.WeakValueDictionary()
+
+def get_resource_weak(key):
+    """Get resource from weak cache."""
+    resource = weak_cache.get(key)
+    if resource is None:
+        resource = CachedResource(f"Data for {key}")
+        weak_cache[key] = resource
+    return resource
+
+# When no strong references exist, objects can be GC'd
+```
+
+## Benchmarking Tools
+
+### Custom Benchmark Decorator
+
+```python
+import time
+from functools import wraps
+
+def benchmark(func):
+    """Decorator to benchmark function execution."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - start
+        print(f"{func.__name__} took {elapsed:.6f} seconds")
+        return result
+    return wrapper
+
+@benchmark
+def slow_function():
+    """Function to benchmark."""
+    time.sleep(0.5)
+    return sum(range(1000000))
+
+result = slow_function()
+```
+
+### Performance Testing with pytest-benchmark
+
+```python
+# Install: pip install pytest-benchmark
+
+def test_list_comprehension(benchmark):
+    """Benchmark list comprehension."""
+    result = benchmark(lambda: [i**2 for i in range(10000)])
+    assert len(result) == 10000
+
+def test_map_function(benchmark):
+    """Benchmark map function."""
+    result = benchmark(lambda: list(map(lambda x: x**2, range(10000))))
+    assert len(result) == 10000
+
+# Run with: pytest test_performance.py --benchmark-compare
+```

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Python virtual environment
+.venv/
+
+# Persistent data (mounted as volume at runtime)
+data/
+
+# Test coverage artifacts
+htmlcov/
+.coverage
+.pytest_cache/
+
+# Git history
+.git/
+.gitignore
+
+# Local repos (mounted as volume at runtime)
+repos/
+
+# Compiled Python files
+*.pyc
+*.pyo
+*.pyd
+__pycache__/
+*.egg-info/
+dist/
+build/
+
+# Environment files (injected at runtime via docker-compose env_file)
+.env
+.env.*
+
+# Editor and OS artifacts
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# SDD / agent artifacts
+.agent/
+.agents/
+.atl/
+.claude/worktrees/
+openspec/
+
+# Docs and non-runtime files
+htmlcov/
+docs/
+tests/

--- a/.env.example
+++ b/.env.example
@@ -207,3 +207,23 @@ DEBUG=false
 
 # Enable development features
 DEVELOPMENT_MODE=true
+
+
+# Voice TTS (respuestas en nota de voz)                                           
+ENABLE_VOICE_REPLIES=false
+VOICE_REPLY_MODE=manual 
+VOICE_REPLY_MAX_WORDS=200 
+EDGE_TTS_VOICE=es-AR-TomasNeural
+
+ 
+# SDD Command 
+ENABLE_SDD=true 
+SDD_PROTECTED_BRANCHES=main,master,develop
+
+Y las del webhook de issues:
+
+# GitHub Issue Webhook
+ENABLE_ISSUE_WEBHOOK=false
+ISSUE_WEBHOOK_REQUIRE_LABEL=true
+ISSUE_WEBHOOK_LABEL=sdd-analyze 
+ISSUE_WEBHOOK_REPO_ALLOWLIST= 

--- a/.env.example
+++ b/.env.example
@@ -227,3 +227,19 @@ ENABLE_ISSUE_WEBHOOK=false
 ISSUE_WEBHOOK_REQUIRE_LABEL=true
 ISSUE_WEBHOOK_LABEL=sdd-analyze 
 ISSUE_WEBHOOK_REPO_ALLOWLIST= 
+# === DOCKER / CONTAINER SETTINGS ===
+# Use these when running the bot inside Docker (via docker-compose).
+# For local Poetry dev, keep the defaults above.
+
+# Approved working directory inside container (mapped to host via volume)
+# Docker default: /workspace  |  Local dev: absolute path on your machine
+# APPROVED_DIRECTORY=/workspace
+
+# SQLite database path inside container (mapped to ./data volume)
+# Docker default: sqlite:////data/bot.db  |  Local dev: sqlite:///data/bot.db
+# DATABASE_URL=sqlite:////data/bot.db
+
+# Local whisper.cpp settings when VOICE_PROVIDER=local inside Docker
+# (binary installed at build time with --build-arg WITH_LOCAL_WHISPER=true)
+# WHISPER_CPP_BINARY_PATH=/usr/local/bin/whisper-cli
+# WHISPER_CPP_MODEL_PATH=/models/ggml-medium.bin

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,10 @@ dmypy.json
 
 # Project-specific
 data/
+workspace/*
+!workspace/.gitkeep
+models/*
+!models/.gitkeep
 *.db
 *.db-journal
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -136,7 +136,6 @@ data/
 .DS_Store
 
 # IDE
-.vscode/
 .idea/
 *.swp
 *.swo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Bot: Debug",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "src.main",
+      "python": "${workspaceFolder}/.venv/bin/python",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "justMyCode": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Test: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "python": "${workspaceFolder}/.venv/bin/python",
+      "cwd": "${workspaceFolder}",
+      "args": ["${file}", "-v", "--no-cov", "--asyncio-mode=auto"],
+      "envFile": "${workspaceFolder}/.env",
+      "justMyCode": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Test: All",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "python": "${workspaceFolder}/.venv/bin/python",
+      "cwd": "${workspaceFolder}",
+      "args": ["tests/", "-v", "--no-cov", "--asyncio-mode=auto"],
+      "envFile": "${workspaceFolder}/.env",
+      "justMyCode": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Attach to Process",
+      "type": "debugpy",
+      "request": "attach",
+      "processId": "${command:pickProcess}",
+      "justMyCode": false
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Bot: Debug",
+      "name": "Bot: Debug (with breakpoints)",
       "type": "debugpy",
       "request": "launch",
       "module": "src.main",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Check venv",
+      "type": "shell",
+      "command": "test -f ${workspaceFolder}/.venv/bin/python || (echo 'ERROR: .venv not found. Run: python3 -m venv .venv && .venv/bin/pip install -e .[dev]' && exit 1)",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/schedule` command**: Create, list, pause, resume, and remove scheduled jobs directly from Telegram. Auto-populates chat, directory, and user from context. Requires `ENABLE_SCHEDULER=true` (#150)
+
 ## [1.6.0] - 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ Extender el bot para un workflow **SDD (Spec-Driven Development)** donde el bot 
 - Nunca modificar código existente del usuario — solo escribir bajo `.agent/`
 - Al implementar `/sdd`: el bot NO ejecuta el fix, solo documenta
 
+### Skills locales disponibles
+
+Instalados en `.claude/skills/` — Claude Code los carga automáticamente cuando son relevantes:
+
+| Skill | Cuándo se activa |
+|-------|-----------------|
+| `fastapi` | Al trabajar en `src/api/` — best practices, Pydantic models, patterns actualizados |
+| `python-performance-optimization` | Al optimizar código lento — cProfile, memory profilers, bottlenecks |
+
 ### Dev local
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,55 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+---
+
+## Fork Context (paulpwo/claude-code-telegram)
+
+Fork of `RichardAtCT/claude-code-telegram`. Upstream: `https://github.com/RichardAtCT/claude-code-telegram`.
+
+### Objetivo del fork
+
+Extender el bot para un workflow **SDD (Spec-Driven Development)** donde el bot actúa como analista técnico: recibe issues de GitHub o pedidos por Telegram, analiza el repo, crea una rama con el pre-análisis documentado, y notifica al usuario. El usuario baja la rama y ejecuta el fix localmente con Claude Code.
+
+### Mejoras planificadas
+
+| # | Feature | Estado | Archivos clave |
+|---|---------|--------|----------------|
+| 1 | Comando `/sdd` — análisis automático + rama + docs | Pendiente | `src/bot/orchestrator.py`, `src/bot/handlers/sdd_handler.py` |
+| 2 | Git safety — bloqueo de push a ramas protegidas | Pendiente | `src/security/`, `src/config/settings.py` |
+| 3 | GitHub issue polling — análisis automático al crearse issues | Pendiente | `src/scheduler/`, `src/api/` |
+| 4 | Send voice (TTS) — respuestas en nota de voz via edge-tts | Pendiente | `src/bot/features/voice_handler.py` |
+
+### Convenciones del fork
+
+- Cada feature va en su propia rama: `feature/sdd-command`, `feature/git-safety`, etc.
+- Los archivos de análisis que genera el bot van siempre bajo `.agent/` en la raíz del repo analizado
+- Nunca modificar código existente del usuario — solo escribir bajo `.agent/`
+- Al implementar `/sdd`: el bot NO ejecuta el fix, solo documenta
+
+### Dev local
+
+```bash
+# Instalar (venv local, no global)
+python3 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+
+# Correr
+.venv/bin/claude-telegram-bot
+
+# Variables de entorno
+cp .env.example .env  # o crear .env manual
+```
+
+### Sync con upstream
+
+```bash
+git fetch upstream
+git merge upstream/main
+```
+
+---
+
 ## Project Overview
 
 Telegram bot providing remote access to Claude Code. Python 3.10+, built with Poetry, using `python-telegram-bot` for Telegram and `claude-agent-sdk` for Claude Code integration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,37 @@ Instalados en `.claude/skills/` — Claude Code los carga automáticamente cuand
 
 ### Dev local
 
+#### Con Docker (recomendado)
+
+```bash
+# 1. Copiar y editar variables de entorno
+cp .env.example .env
+# Editar .env: TELEGRAM_BOT_TOKEN, TELEGRAM_BOT_USERNAME, APPROVED_DIRECTORY=/workspace, etc.
+
+# 2. Crear directorios de volúmenes
+mkdir -p data workspace models
+
+# 3. Construir y correr
+make docker-build
+make docker-run          # docker-compose up -d
+
+# Ver logs
+docker-compose logs -f
+
+# Detener
+docker-compose down
+```
+
+Para usar whisper local (VOICE_PROVIDER=local):
+
+```bash
+# Build con whisper-cli compilado (agrega ~400MB y tiempo de build)
+docker build --build-arg WITH_LOCAL_WHISPER=true -t claude-telegram-bot:local .
+# Luego poner el modelo en ./models/ggml-medium.bin
+```
+
+#### Con Poetry (desarrollo local sin Docker)
+
 ```bash
 # Instalar (venv local, no global)
 python3 -m venv .venv
@@ -51,6 +82,14 @@ python3 -m venv .venv
 # Variables de entorno
 cp .env.example .env  # o crear .env manual
 ```
+
+#### Scripts de voz
+
+Los scripts de voz están en `scripts/voice/` (copiados a `/app/scripts/voice/` dentro del contenedor):
+
+- `scripts/voice/transcribe-voice.sh` — transcripción con whisper-cli
+- `scripts/voice/text-to-voice.sh` — TTS con edge-tts
+- `scripts/voice/send-voice-telegram.sh` — envío de nota de voz via Telegram API
 
 ### Sync con upstream
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Instalados en `.claude/skills/` — Claude Code los carga automáticamente cuand
 
 | Skill | Cuándo se activa |
 |-------|-----------------|
+| `git-paul` | Al hacer commits, crear ramas, abrir PRs — Gitmoji, PascalCase branches, sin Co-Authored-By Claude |
 | `fastapi` | Al trabajar en `src/api/` — best practices, Pydantic models, patterns actualizados |
 | `python-performance-optimization` | Al optimizar código lento — cProfile, memory profilers, bottlenecks |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ All datetimes use timezone-aware UTC: `datetime.now(UTC)` (not `datetime.utcnow(
 
 ### Agentic mode
 
-Agentic mode commands: `/start`, `/new`, `/status`, `/verbose`, `/repo`. If `ENABLE_PROJECT_THREADS=true`: `/sync_threads`. To add a new command:
+Agentic mode commands: `/start`, `/new`, `/status`, `/verbose`, `/repo`. If `ENABLE_PROJECT_THREADS=true`: `/sync_threads`. If `ENABLE_SCHEDULER=true`: `/schedule`. To add a new command:
 
 1. Add handler function in `src/bot/orchestrator.py`
 2. Register in `MessageOrchestrator._register_agentic_handlers()`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,105 @@
+# syntax=docker/dockerfile:1
+# Claude Code Telegram Bot — Multi-stage Dockerfile
+#
+# Stages:
+#   builder         — installs Python deps into /install prefix
+#   node-builder    — installs Claude Code CLI via npm (isolated)
+#   whisper-builder — (opt-in) compiles whisper-cli from source
+#   runtime         — lean production image
+
+ARG PYTHON_VERSION=3.11
+ARG WITH_LOCAL_WHISPER=false
+
+# =============================================================================
+# Stage 1: builder — Python deps via pip
+# =============================================================================
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+WORKDIR /build
+
+# Copy project files (src/ and README.md needed by the build backend)
+COPY pyproject.toml poetry.lock README.md ./
+COPY src/ ./src/
+
+# Install project + all production deps into /install prefix
+# Uses poetry-core as build backend (no Poetry CLI needed)
+RUN pip install --no-cache-dir --prefix=/install .
+
+# =============================================================================
+# Stage 2: node-builder — Claude Code CLI (isolated, no npm in runtime)
+# Note: @anthropic-ai/claude-code requires Node.js (postinstall scripts incompatible with Bun)
+# =============================================================================
+FROM node:lts-slim AS node-builder
+
+RUN npm install -g @anthropic-ai/claude-code --no-update-notifier \
+    && npm cache clean --force
+
+# =============================================================================
+# Stage 3: whisper-builder — compile whisper-cli from source (opt-in)
+# =============================================================================
+FROM python:${PYTHON_VERSION}-slim AS whisper-builder
+
+ARG WITH_LOCAL_WHISPER=false
+
+RUN if [ "$WITH_LOCAL_WHISPER" = "true" ]; then \
+      apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake git ca-certificates \
+      && rm -rf /var/lib/apt/lists/* \
+      && git clone --depth 1 https://github.com/ggerganov/whisper.cpp /whisper.cpp \
+      && cmake -B /whisper.cpp/build -S /whisper.cpp \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DWHISPER_BUILD_TESTS=OFF \
+           -DWHISPER_BUILD_EXAMPLES=ON \
+      && cmake --build /whisper.cpp/build --target whisper-cli -j$(nproc) \
+      && cp /whisper.cpp/build/bin/whisper-cli /usr/local/bin/whisper-cli; \
+    else \
+      mkdir -p /usr/local/bin \
+      && printf '#!/bin/sh\necho "whisper-cli not available (built without WITH_LOCAL_WHISPER=true)"\nexit 1\n' \
+         > /usr/local/bin/whisper-cli \
+      && chmod +x /usr/local/bin/whisper-cli; \
+    fi
+
+# =============================================================================
+# Stage 4: runtime — lean production image
+# =============================================================================
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+# System dependencies — no gnupg/NodeSource needed (Node comes from node-builder)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        curl \
+        jq \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install edge-tts (TTS for voice replies)
+RUN pip install --no-cache-dir edge-tts
+
+# Copy pre-installed Python packages from builder
+COPY --from=builder /install /usr/local
+
+# Copy Node.js runtime + Claude Code CLI (no npm/npx — not needed at runtime)
+COPY --from=node-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node-builder /usr/local/bin/claude /usr/local/bin/claude
+
+# Copy whisper-cli stub or real binary
+COPY --from=whisper-builder /usr/local/bin/whisper-cli /usr/local/bin/whisper-cli
+
+WORKDIR /app
+
+# Copy application source
+COPY src/ ./src/
+COPY pyproject.toml ./
+
+# Copy voice scripts into image (must live inside container — ~/.claude/ is host-only)
+COPY scripts/voice/ ./scripts/voice/
+RUN chmod +x ./scripts/voice/*.sh
+
+# Volume mount points:
+#   /data       — SQLite database persistence (DATABASE_URL=sqlite:////data/bot.db)
+#   /workspace  — approved working directory (APPROVED_DIRECTORY=/workspace)
+#   /models     — whisper model files (WHISPER_CPP_MODEL_PATH=/models/ggml-medium.bin)
+VOLUME ["/data", "/workspace", "/models"]
+
+ENTRYPOINT ["python", "-m", "src.main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN if [ "$WITH_LOCAL_WHISPER" = "true" ]; then \
       && git clone --depth 1 https://github.com/ggerganov/whisper.cpp /whisper.cpp \
       && cmake -B /whisper.cpp/build -S /whisper.cpp \
            -DCMAKE_BUILD_TYPE=Release \
+           -DBUILD_SHARED_LIBS=OFF \
            -DWHISPER_BUILD_TESTS=OFF \
            -DWHISPER_BUILD_EXAMPLES=ON \
       && cmake --build /whisper.cpp/build --target whisper-cli -j$(nproc) \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: install dev test lint format clean help run run-watch run-remote remote-attach remote-stop \
-       bump-patch bump-minor bump-major release version
+       bump-patch bump-minor bump-major release version \
+       docker-build docker-run docker-push
 
 # Default target
 help:
@@ -20,6 +21,9 @@ help:
 	@echo "  run-remote    - Start bot in tmux on remote Mac (unlocks keychain)"
 	@echo "  remote-attach - Attach to running bot tmux session"
 	@echo "  remote-stop   - Stop the bot tmux session"
+	@echo "  docker-build  - Build Docker image (claude-telegram-bot:latest)"
+	@echo "  docker-run    - Start bot via docker-compose (detached)"
+	@echo "  docker-push   - Push image to registry"
 
 install:
 	poetry install --no-dev
@@ -102,6 +106,17 @@ bump-major:  ## Bump major version, commit, and tag
 	git tag "v$$NEW_VERSION" && \
 	git push && git push origin "v$$NEW_VERSION" && \
 	echo "Released v$$NEW_VERSION. Tag pushed — release workflow will run on GitHub."
+
+# --- Docker ---
+
+docker-build:  ## Build the Docker image (tag: claude-telegram-bot:latest)
+	docker build -t claude-telegram-bot:latest .
+
+docker-run:  ## Start bot via docker-compose (detached)
+	docker-compose up -d
+
+docker-push:  ## Push image to registry (set IMAGE_REPO env var or edit this target)
+	docker push claude-telegram-bot:latest
 
 release:  ## Push the current version tag to trigger the release workflow
 	CURRENT_VERSION=$$(poetry version -s) && \

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The bot supports two interaction modes:
 The default conversational mode. Just talk to Claude naturally -- no special commands required.
 
 **Commands:** `/start`, `/new`, `/status`, `/verbose`, `/repo`
-If `ENABLE_PROJECT_THREADS=true`: `/sync_threads`
+If `ENABLE_PROJECT_THREADS=true`: `/sync_threads` | If `ENABLE_SCHEDULER=true`: `/schedule`
 
 ```
 You: What files are in this project?
@@ -157,8 +157,8 @@ Use `/repo` to list cloned repos in your workspace, or `/repo <name>` to switch 
 
 Set `AGENTIC_MODE=false` to enable the full 13-command terminal-like interface with directory navigation, inline keyboards, quick actions, git integration, and session export.
 
-**Commands:** `/start`, `/help`, `/new`, `/continue`, `/end`, `/status`, `/cd`, `/ls`, `/pwd`, `/projects`, `/export`, `/actions`, `/git`  
-If `ENABLE_PROJECT_THREADS=true`: `/sync_threads`
+**Commands:** `/start`, `/help`, `/new`, `/continue`, `/end`, `/status`, `/cd`, `/ls`, `/pwd`, `/projects`, `/export`, `/actions`, `/git`
+If `ENABLE_PROJECT_THREADS=true`: `/sync_threads` | If `ENABLE_SCHEDULER=true`: `/schedule`
 
 ```
 You: /cd my-web-app
@@ -176,7 +176,7 @@ Bot: [Run Tests] [Install Deps] [Format Code] [Run Linter]
 Beyond direct chat, the bot can respond to external triggers:
 
 - **Webhooks** -- Receive GitHub events (push, PR, issues) and route them through Claude for automated summaries or code review
-- **Scheduler** -- Run recurring Claude tasks on a cron schedule (e.g., daily code health checks)
+- **Scheduler** -- Run recurring Claude tasks on a cron schedule (e.g., daily code health checks). Manage jobs directly from Telegram with `/schedule`
 - **Notifications** -- Deliver agent responses to configured Telegram chats
 
 Enable with `ENABLE_API_SERVER=true` and `ENABLE_SCHEDULER=true`. See [docs/setup.md](docs/setup.md) for configuration.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Set to true to compile whisper-cli from source (adds ~400MB, needs more build time)
+        WITH_LOCAL_WHISPER: "false"
+    image: claude-telegram-bot:latest
+    env_file: .env
+    volumes:
+      # SQLite database persistence — matches DATABASE_URL=sqlite:////data/bot.db
+      - ./data:/data
+      # Approved working directory — matches APPROVED_DIRECTORY=/workspace
+      - ./workspace:/workspace
+      # Whisper model files — matches WHISPER_CPP_MODEL_PATH=/models/ggml-medium.bin
+      # (leave empty when VOICE_PROVIDER=mistral or openai)
+      - ./models:/models
+    restart: unless-stopped
+    # Optional: expose API server port when ENABLE_API_SERVER=true
+    # ports:
+    #   - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,19 +4,28 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Set to true to compile whisper-cli from source (adds ~400MB, needs more build time)
-        WITH_LOCAL_WHISPER: "false"
-    image: claude-telegram-bot:latest
+        # Set to true to compile whisper-cli from source (VOICE_PROVIDER=local)
+        # Adds ~400MB and significant build time — only needed for offline transcription
+        WITH_LOCAL_WHISPER: "true"
+    image: claude-telegram-bot:local
     env_file: .env
+    environment:
+      # Container-internal paths — override .env host paths when running in Docker.
+      # These match the volume mounts below and must not be changed.
+      APPROVED_DIRECTORY: /workspace
+      WHISPER_CPP_BINARY_PATH: /usr/local/bin/whisper-cli
+      WHISPER_CPP_MODEL_PATH: /models/ggml-medium.bin
     volumes:
       # SQLite database persistence — matches DATABASE_URL=sqlite:////data/bot.db
       - ./data:/data
-      # Approved working directory — matches APPROVED_DIRECTORY=/workspace
+      # Approved working directory — set APPROVED_DIRECTORY=/workspace in .env (or leave as-is, overridden above)
       - ./workspace:/workspace
-      # Whisper model files — matches WHISPER_CPP_MODEL_PATH=/models/ggml-medium.bin
-      # (leave empty when VOICE_PROVIDER=mistral or openai)
+      # Whisper model files — place ggml-medium.bin (or any model) here
+      # Download: https://huggingface.co/ggerganov/whisper.cpp
       - ./models:/models
+      # .env file mounted so pydantic-settings can find it inside the container
+      - ./.env:/app/.env:ro
     restart: unless-stopped
-    # Optional: expose API server port when ENABLE_API_SERVER=true
+    # Uncomment to expose the webhook API server (requires ENABLE_API_SERVER=true)
     # ports:
     #   - "8080:8080"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,12 +6,7 @@ Fork de `RichardAtCT/claude-code-telegram` orientado a un workflow **SDD (Spec-D
 
 ## Contexto y objetivo
 
-El bot reemplaza a OpenClaw como bridge Telegram → Claude Code.
-
-**Por qué se descartó OpenClaw:**
-- Kimi K2 respondía él mismo en vez de delegar a Claude Code
-- Mezclaba idiomas (chino/español) de forma impredecible
-- Acceso shell libre sin granularidad de permisos
+Bridge directo Telegram → Claude Code orientado a un workflow SDD donde el bot actúa como analista técnico remoto.
 
 **El workflow objetivo:**
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ GitHub Issue / mensaje Telegram
         ↓
 Bot (Claude Code remoto)
   → Analiza el repo
-  → Crea rama analysis/issue-N-slug
+  → Crea rama Analysis/Issue{N}{Slug}
   → Escribe .agent/planning/sdd.md
   → Escribe .agent/context/files.md
   → Escribe .agent/context/approach.md
@@ -46,13 +46,13 @@ Comando dedicado que ejecuta el workflow SDD completo en un solo paso.
 1. Parsea el input (URL de issue o descripción libre)
 2. Si es URL: lee el issue via `gh issue view`
 3. Determina el repo a analizar (por thread activo o argumento)
-4. Crea rama `analysis/issue-N-slug` (o `analysis/slug` si no hay número)
+4. Crea rama `Analysis/Issue{N}{DescripcionEnPascalCase}` (ej: `Analysis/Issue5DarkMode`)
 5. Explora el repo: estructura, archivos relevantes, contexto del problema
 6. Escribe bajo `.agent/`:
    - `planning/sdd.md` — spec: qué hay que hacer, criterios de aceptación
    - `context/files.md` — archivos relevantes y su rol
    - `context/approach.md` — enfoque sugerido con alternativas y tradeoffs
-7. `git commit` + `git push origin analysis/...`
+7. `git commit` con Gitmoji (`📝 docs(analysis): agregar pre-análisis issue #N`) + `git push`
 8. Responde en Telegram con resumen y nombre de la rama
 
 **Restricciones del comando:**
@@ -72,7 +72,7 @@ Analizá el repo en {working_dir}.
 Contexto de la tarea: {issue_content}
 
 Instrucciones:
-1. Creá la rama analysis/{slug}
+1. Creá la rama Analysis/Issue{N}{DescripcionEnPascalCase}
 2. Explorá el repo — entendé la estructura y los archivos relevantes
 3. Escribí en .agent/planning/sdd.md el spec completo
 4. Escribí en .agent/context/files.md los archivos relevantes y su rol
@@ -206,6 +206,66 @@ Feature 3 (issue polling) → automatización
 Feature 4 (voice TTS)    → UX mejorada
 Deploy VM                → producción
 ```
+
+---
+
+## Convenciones Git (git-paul)
+
+Aplican tanto para el desarrollo de este repo como para los commits que el bot genera en los repos analizados.
+
+### Branches — PascalCase
+
+```
+<Tipo>/<DescripcionEnPascalCase>
+```
+
+| Tipo | Cuándo |
+|------|--------|
+| `Feat/` | Nueva funcionalidad |
+| `Fix/` | Bug fix |
+| `Refactor/` | Refactor sin cambio funcional |
+| `Chore/` | Config, deps, mantenimiento |
+| `Docs/` | Solo documentación |
+| `Analysis/` | Ramas SDD generadas por el bot |
+
+**Ejemplos para este repo:**
+- `Feat/SddCommand`
+- `Fix/GitSafetyProtectedBranches`
+- `Feat/VoiceTtsReplies`
+
+**Ejemplos generados por el bot en repos analizados:**
+- `Analysis/Issue5DarkMode`
+- `Analysis/FixAuthRedirect`
+
+### Commits — Gitmoji + imperativo
+
+```
+<emoji> <tipo>(<scope>): <descripción en imperativo>
+```
+
+| Emoji | Cuándo |
+|-------|--------|
+| ✨ | Nueva funcionalidad |
+| 🐛 | Fix de bug |
+| 🔒️ | Fix de seguridad |
+| 📝 | Documentación / archivos `.agent/` |
+| ♻️ | Refactor |
+| 🔧 | Config |
+| ✅ | Tests |
+
+**Ejemplos:**
+```bash
+✨ feat(sdd): agregar comando /sdd con workflow análisis completo
+🔒 security(git): bloquear push a ramas protegidas en ToolMonitor
+📝 docs(analysis): agregar pre-análisis issue #5 dark mode
+```
+
+### Reglas absolutas
+
+- **NUNCA** `Co-Authored-By: Claude` ni menciones a Claude/Anthropic en commits
+- **NUNCA** `--no-verify` ni saltarse hooks
+- **NUNCA** force push a `main` o `master`
+- Stagear archivos específicos — nunca `git add -A` sin revisar
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,225 @@
+# Roadmap — paulpwo/claude-code-telegram
+
+Fork de `RichardAtCT/claude-code-telegram` orientado a un workflow **SDD (Spec-Driven Development)** donde el bot actúa como analista técnico remoto.
+
+---
+
+## Contexto y objetivo
+
+El bot reemplaza a OpenClaw como bridge Telegram → Claude Code.
+
+**Por qué se descartó OpenClaw:**
+- Kimi K2 respondía él mismo en vez de delegar a Claude Code
+- Mezclaba idiomas (chino/español) de forma impredecible
+- Acceso shell libre sin granularidad de permisos
+
+**El workflow objetivo:**
+```
+GitHub Issue / mensaje Telegram
+        ↓
+Bot (Claude Code remoto)
+  → Analiza el repo
+  → Crea rama analysis/issue-N-slug
+  → Escribe .agent/planning/sdd.md
+  → Escribe .agent/context/files.md
+  → Escribe .agent/context/approach.md
+  → Commitea y pushea
+  → Notifica por Telegram: "rama lista"
+        ↓
+Paul localmente
+  → git pull
+  → Claude Code local lee los .agent/ docs
+  → Ejecuta el fix
+```
+
+---
+
+## Features planificadas
+
+### Feature 1 — Comando `/sdd` (PRIORIDAD ALTA)
+
+**Qué hace:**
+Comando dedicado que ejecuta el workflow SDD completo en un solo paso.
+
+**Uso esperado:**
+```
+/sdd https://github.com/paulpwo/portfolio/issues/5
+/sdd Agregar dark mode al portfolio
+```
+
+**Flujo:**
+1. Parsea el input (URL de issue o descripción libre)
+2. Si es URL: lee el issue via `gh issue view`
+3. Determina el repo a analizar (por thread activo o argumento)
+4. Crea rama `analysis/issue-N-slug` (o `analysis/slug` si no hay número)
+5. Explora el repo: estructura, archivos relevantes, contexto del problema
+6. Escribe bajo `.agent/`:
+   - `planning/sdd.md` — spec: qué hay que hacer, criterios de aceptación
+   - `context/files.md` — archivos relevantes y su rol
+   - `context/approach.md` — enfoque sugerido con alternativas y tradeoffs
+7. `git commit` + `git push origin analysis/...`
+8. Responde en Telegram con resumen y nombre de la rama
+
+**Restricciones del comando:**
+- NO modifica código existente — solo escribe bajo `.agent/`
+- NO abre PRs
+- NO ejecuta tests ni builds
+
+**Archivos a crear/modificar:**
+- `src/bot/handlers/sdd_handler.py` — handler principal
+- `src/bot/orchestrator.py` — registrar el comando
+- `src/config/settings.py` — config `SDD_PROTECTED_BRANCHES`
+- `src/config/features.py` — feature flag `ENABLE_SDD`
+
+**Prompt base para Claude Code:**
+```
+Analizá el repo en {working_dir}. 
+Contexto de la tarea: {issue_content}
+
+Instrucciones:
+1. Creá la rama analysis/{slug}
+2. Explorá el repo — entendé la estructura y los archivos relevantes
+3. Escribí en .agent/planning/sdd.md el spec completo
+4. Escribí en .agent/context/files.md los archivos relevantes y su rol
+5. Escribí en .agent/context/approach.md el enfoque sugerido con alternativas
+6. Commitea los archivos .agent/ y pusheá la rama
+7. NO modifiques código existente
+```
+
+---
+
+### Feature 2 — Git Safety (PRIORIDAD ALTA)
+
+**Qué hace:**
+Bloquea operaciones git destructivas a nivel de middleware, independientemente de lo que Claude decida hacer.
+
+**Config nueva:**
+```env
+GIT_PROTECTED_BRANCHES=main,develop,master
+GIT_ALLOW_FORCE_PUSH=false
+GIT_ALLOW_DELETE_BRANCH=false
+```
+
+**Implementación:**
+- Interceptar en `ToolMonitor` (`src/claude/tool_monitor.py`) las llamadas Bash que contengan:
+  - `git push origin main` / `git push origin develop`
+  - `git push --force` / `git push -f`
+  - `git branch -D`
+  - `git reset --hard` en ramas protegidas
+- Lanzar excepción con mensaje claro: "Push a rama protegida bloqueado"
+
+**Archivos a modificar:**
+- `src/claude/tool_monitor.py` — agregar validación git
+- `src/config/settings.py` — agregar `GIT_PROTECTED_BRANCHES`
+
+---
+
+### Feature 3 — GitHub Issue Polling (PRIORIDAD MEDIA)
+
+**Qué hace:**
+Job programado que detecta issues nuevos en repos configurados y dispara el análisis SDD automáticamente, sin que Paul tenga que mandarlo por Telegram.
+
+**Config nueva:**
+```env
+ENABLE_ISSUE_POLLING=true
+GITHUB_POLLING_REPOS=paulpwo/portfolio,paulpwo/otro-repo
+GITHUB_POLLING_INTERVAL_MINUTES=15
+GITHUB_POLLING_LABEL=sdd-analyze   # solo issues con este label
+```
+
+**Flujo:**
+1. APScheduler corre cada N minutos
+2. Consulta `gh issue list --state open --label sdd-analyze` para cada repo
+3. Filtra issues que no hayan sido procesados (tabla nueva en SQLite: `processed_issues`)
+4. Para cada issue nuevo: dispara el workflow `/sdd` automáticamente
+5. Notifica por Telegram que empezó el análisis
+
+**Archivos a crear/modificar:**
+- `src/scheduler/github_poller.py` — job nuevo
+- `src/storage/` — tabla `processed_issues`
+- `src/config/settings.py` — config polling
+
+---
+
+### Feature 4 — Send Voice / TTS (PRIORIDAD MEDIA)
+
+**Qué hace:**
+Claude responde con nota de voz además de texto cuando el usuario lo pide o cuando la respuesta es corta.
+
+**Stack elegido:**
+- TTS: `edge-tts` (ya instalado en el sistema, voz `es-AR-TomasNeural`)
+- Envío: Telegram `sendVoice` API (OGG/Opus)
+- Script existente: `~/.claude/scripts/text-to-voice.sh` + `~/.claude/scripts/send-voice-telegram.sh`
+
+**Activación:**
+- Comando `/voice on|off` por sesión
+- O automático para respuestas < 200 palabras cuando `VOICE_REPLIES=auto`
+
+**Config nueva:**
+```env
+ENABLE_VOICE_REPLIES=false          # off por defecto
+VOICE_REPLY_MAX_WORDS=200           # límite para auto-mode
+EDGE_TTS_VOICE=es-AR-TomasNeural
+```
+
+**Archivos a crear/modificar:**
+- `src/bot/features/voice_handler.py` — agregar clase `VoiceSender`
+- `src/bot/orchestrator.py` — comando `/voice`
+- `src/config/settings.py` — config TTS
+
+---
+
+## Configuración de voice local (whisper)
+
+El proyecto ya soporta whisper.cpp local. Config para este entorno:
+
+```env
+ENABLE_VOICE_MESSAGES=true
+VOICE_PROVIDER=local
+WHISPER_CPP_BINARY_PATH=/opt/homebrew/bin/whisper-cli
+WHISPER_CPP_MODEL_PATH=/Users/developer/.local/share/whisper/ggml-medium.bin
+```
+
+---
+
+## Deploy en VM (paso final)
+
+Cuando las features estén estables en local, reemplazar OpenClaw en la VM.
+
+**VM actual:** AWS EC2 t3.small, Ubuntu 22.04, IP 23.20.232.38
+
+**Plan de deploy:**
+1. `pm2 stop openclaw` en la VM
+2. Clonar el fork: `git clone git@github.com:paulpwo/claude-code-telegram.git`
+3. Crear venv Python + instalar dependencias
+4. Configurar `.env` con tokens de producción
+5. Configurar PM2: `pm2 start .venv/bin/claude-telegram-bot --name claude-telegram`
+6. Configurar branch protection en GitHub (main, develop)
+7. Verificar con `/sdd` desde Telegram
+
+**Repos a configurar en APPROVED_DIRECTORY:**
+- `/home/ubuntu/repos` (igual que la config de OpenClaw anterior)
+
+---
+
+## Orden de implementación sugerido
+
+```
+Feature 2 (git safety)   → base de seguridad, rápido de hacer
+Feature 1 (/sdd)         → el core del workflow
+Feature 3 (issue polling) → automatización
+Feature 4 (voice TTS)    → UX mejorada
+Deploy VM                → producción
+```
+
+---
+
+## Sync con upstream
+
+Cuando `RichardAtCT` saque updates:
+```bash
+git fetch upstream
+git merge upstream/main
+```
+
+Conflictos esperados en: `src/bot/orchestrator.py`, `src/config/settings.py`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ GitHub Issue / mensaje Telegram
         ↓
 Bot (Claude Code remoto)
   → Analiza el repo
-  → Crea rama Analysis/Issue{N}{Slug}
+  → Infiere tipo y crea rama {Tipo}/Issue{N}{Slug}
   → Escribe .agent/planning/sdd.md
   → Escribe .agent/context/files.md
   → Escribe .agent/context/approach.md
@@ -46,7 +46,7 @@ Comando dedicado que ejecuta el workflow SDD completo en un solo paso.
 1. Parsea el input (URL de issue o descripción libre)
 2. Si es URL: lee el issue via `gh issue view`
 3. Determina el repo a analizar (por thread activo o argumento)
-4. Crea rama `Analysis/Issue{N}{DescripcionEnPascalCase}` (ej: `Analysis/Issue5DarkMode`)
+4. Infiere el tipo de rama del issue (`Feat/`, `Fix/`, `Chore/`, etc.) y crea `{Tipo}/Issue{N}{DescripcionEnPascalCase}` (ej: `Feat/Issue5DarkMode`, `Fix/Issue12AuthRedirect`)
 5. Explora el repo: estructura, archivos relevantes, contexto del problema
 6. Escribe bajo `.agent/`:
    - `planning/sdd.md` — spec: qué hay que hacer, criterios de aceptación
@@ -72,7 +72,7 @@ Analizá el repo en {working_dir}.
 Contexto de la tarea: {issue_content}
 
 Instrucciones:
-1. Creá la rama Analysis/Issue{N}{DescripcionEnPascalCase}
+1. Inferí el tipo de trabajo del issue (Feat, Fix, Chore, etc.) y creá la rama `{Tipo}/Issue{N}{DescripcionEnPascalCase}`
 2. Explorá el repo — entendé la estructura y los archivos relevantes
 3. Escribí en .agent/planning/sdd.md el spec completo
 4. Escribí en .agent/context/files.md los archivos relevantes y su rol
@@ -226,16 +226,15 @@ Aplican tanto para el desarrollo de este repo como para los commits que el bot g
 | `Refactor/` | Refactor sin cambio funcional |
 | `Chore/` | Config, deps, mantenimiento |
 | `Docs/` | Solo documentación |
-| `Analysis/` | Ramas SDD generadas por el bot |
-
 **Ejemplos para este repo:**
 - `Feat/SddCommand`
 - `Fix/GitSafetyProtectedBranches`
 - `Feat/VoiceTtsReplies`
 
 **Ejemplos generados por el bot en repos analizados:**
-- `Analysis/Issue5DarkMode`
-- `Analysis/FixAuthRedirect`
+- `Feat/Issue5DarkMode` — issue de nueva feature
+- `Fix/Issue12AuthRedirect` — issue de bug
+- `Chore/Issue8UpdateDeps` — mantenimiento
 
 ### Commits — Gitmoji + imperativo
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,12 @@ VOICE_MAX_FILE_SIZE_MB=20            # Max Telegram voice file size to download 
 # Local whisper.cpp settings (only used when VOICE_PROVIDER=local)
 WHISPER_CPP_BINARY_PATH=             # Path to whisper.cpp binary (auto-detected from PATH if unset)
 WHISPER_CPP_MODEL_PATH=base          # Path to GGML model file or model name (base, small, medium, large)
+
+# Voice TTS replies — outgoing voice notes via edge-tts (pip install edge-tts)
+ENABLE_VOICE_REPLIES=false           # Master flag — off by default (opt-in)
+VOICE_REPLY_MODE=manual              # 'manual' (on/off via /voice) or 'auto' (word-count gated)
+VOICE_REPLY_MAX_WORDS=200            # Max words for auto mode (1-500); replies above this → text
+EDGE_TTS_VOICE=es-AR-TomasNeural    # edge-tts voice name (see: edge-tts --list-voices)
 ```
 
 #### Agentic Platform

--- a/docs/github-webhook-setup.md
+++ b/docs/github-webhook-setup.md
@@ -1,0 +1,166 @@
+# GitHub Webhook Setup — Automatic SDD Analysis
+
+This document explains how to configure a GitHub webhook so that the bot
+automatically triggers an SDD pre-analysis whenever a qualifying issue is
+created or labeled.
+
+---
+
+## How it works
+
+When GitHub sends an `issues` webhook event to `/webhooks/github`, the bot
+checks whether the event should trigger an automatic SDD analysis.  Two
+actions are handled:
+
+| Action | Trigger condition |
+|--------|------------------|
+| `opened` | Issue was just created and already has the required label |
+| `labeled` | A label was added to an existing issue and it matches the required label |
+
+When the condition is met:
+1. An immediate Telegram notification is sent ("SDD auto-analysis started").
+2. Claude runs the same workflow as `/sdd <issue-url>`:
+   - Creates a branch (`Feat/Issue7FixLogin`, etc.)
+   - Writes `.agent/planning/sdd.md`, `.agent/context/files.md`, `.agent/context/approach.md`
+   - Commits and pushes the branch
+3. Claude's summary is delivered to the configured Telegram chats.
+
+---
+
+## Prerequisites
+
+- The bot must be reachable from the internet (or use a tunnel for local dev).
+- `ENABLE_API_SERVER=true` in your `.env`.
+- `GITHUB_WEBHOOK_SECRET` must match the secret you set in GitHub.
+- `ENABLE_ISSUE_WEBHOOK=true` in your `.env`.
+
+---
+
+## GitHub configuration (Settings → Webhooks)
+
+1. Go to your repository → **Settings** → **Webhooks** → **Add webhook**.
+2. Fill in the form:
+
+   | Field | Value |
+   |-------|-------|
+   | **Payload URL** | `https://<your-domain>/webhooks/github` |
+   | **Content type** | `application/json` |
+   | **Secret** | A random string (copy it — you'll put it in `.env`) |
+   | **Which events?** | Select *Let me select individual events* → tick **Issues** |
+   | **Active** | ✅ |
+
+3. Click **Add webhook**.  GitHub will send a `ping` event — the bot returns
+   `200 OK` for all successfully verified requests.
+
+---
+
+## Option A — With label (recommended)
+
+Only issues that carry the label `sdd-analyze` (or your configured label)
+trigger the analysis.  This lets you opt-in per issue.
+
+**.env settings:**
+
+```dotenv
+ENABLE_ISSUE_WEBHOOK=true
+ISSUE_WEBHOOK_REQUIRE_LABEL=true
+ISSUE_WEBHOOK_LABEL=sdd-analyze        # create this label in your repo
+ISSUE_WEBHOOK_REPO_ALLOWLIST=          # empty = all repos allowed
+```
+
+**How to trigger:**
+
+- **At creation**: open the issue and add the label `sdd-analyze` before
+  submitting (or edit + save immediately after).
+- **After creation**: add the label `sdd-analyze` to any existing issue — the
+  `labeled` event fires and triggers the analysis.
+
+---
+
+## Option B — Without label (all new issues)
+
+Every new issue triggers an automatic analysis.  Suitable for small repos
+where every issue is SDD-worthy.
+
+**.env settings:**
+
+```dotenv
+ENABLE_ISSUE_WEBHOOK=true
+ISSUE_WEBHOOK_REQUIRE_LABEL=false
+ISSUE_WEBHOOK_REPO_ALLOWLIST=owner/my-repo   # restrict to one repo (optional)
+```
+
+> **Warning**: with `ISSUE_WEBHOOK_REQUIRE_LABEL=false` and an empty
+> allowlist, *every* issue opened in *any* repo that sends webhooks to this
+> bot will trigger a Claude run.  Use `ISSUE_WEBHOOK_REPO_ALLOWLIST` to
+> restrict to specific repos.
+
+---
+
+## Environment variables reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_ISSUE_WEBHOOK` | `false` | Master switch for the feature |
+| `ISSUE_WEBHOOK_REQUIRE_LABEL` | `true` | Only process labeled issues |
+| `ISSUE_WEBHOOK_LABEL` | `sdd-analyze` | Label name that activates analysis |
+| `ISSUE_WEBHOOK_REPO_ALLOWLIST` | *(empty)* | Comma-separated `owner/repo` list; empty = all repos |
+| `GITHUB_WEBHOOK_SECRET` | *(required)* | HMAC secret set in GitHub webhook settings |
+| `ENABLE_API_SERVER` | `false` | Must be `true` to receive webhooks |
+| `API_SERVER_PORT` | `8080` | Port the FastAPI server listens on |
+| `NOTIFICATION_CHAT_IDS` | *(empty)* | Comma-separated Telegram chat IDs for notifications |
+
+---
+
+## Testing locally with `gh webhook forward`
+
+The GitHub CLI can forward webhooks from GitHub to your local bot without
+exposing a public URL:
+
+```bash
+# Requires: gh auth login + gh extension install github/gh-webhook
+gh webhook forward \
+  --repo=owner/my-repo \
+  --events=issues \
+  --url=http://localhost:8080/webhooks/github
+```
+
+> `gh webhook forward` does **not** send HMAC signatures, so you may need to
+> temporarily set `GITHUB_WEBHOOK_SECRET` to an empty string and relax
+> signature verification for local testing — or use a tool like `ngrok`
+> instead to get a real HTTPS URL.
+
+### With ngrok
+
+```bash
+ngrok http 8080
+# Copy the https URL and set it as the Payload URL in GitHub
+```
+
+---
+
+## Verifying it works
+
+1. Set all required env vars and restart the bot.
+2. Create a new GitHub issue (Option A: add the `sdd-analyze` label).
+3. Check the bot logs for:
+   ```
+   GitHub issue webhook filter result  should_trigger=True reason=ok
+   SDD analysis triggered from GitHub issue webhook  repo=owner/repo  issue_number=7
+   ```
+4. You should receive a Telegram notification within seconds and a Claude
+   response within 1–2 minutes (depending on repo size).
+5. Check the repo — a new branch `Feat/Issue7...` should exist with `.agent/`
+   documents committed.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| 401 from webhook | Wrong secret | Match `GITHUB_WEBHOOK_SECRET` with GitHub |
+| 500 from webhook | Secret not configured | Set `GITHUB_WEBHOOK_SECRET` in `.env` |
+| No Telegram message | `NOTIFICATION_CHAT_IDS` empty | Set at least one chat ID |
+| Analysis runs but no branch | `gh` CLI not authenticated | Run `gh auth login` in the bot env |
+| Every issue triggers, not just labeled | `ISSUE_WEBHOOK_REQUIRE_LABEL=false` | Set to `true` |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -173,7 +173,23 @@ ENABLE_SCHEDULER=true
 NOTIFICATION_CHAT_IDS=123456789  # Where to deliver results
 ```
 
-Jobs are managed programmatically and persist in the SQLite database.
+Jobs persist in the SQLite database and survive bot restarts. Manage them directly from Telegram with the `/schedule` command:
+
+```
+/schedule list                                      # List all jobs (active + paused)
+/schedule add <name> <min> <hour> <day> <month> <weekday> <prompt>
+/schedule remove <job_id>                           # Remove a job
+/schedule pause <job_id>                            # Pause without deleting
+/schedule resume <job_id>                           # Resume a paused job
+```
+
+Example -- create a job that runs every weekday at 9 AM:
+
+```
+/schedule add daily-report 0 9 * * 1-5 Summarize yesterday's git commits
+```
+
+The `chat_id`, `working_directory`, and `created_by` fields are auto-populated from your current Telegram context. Results are delivered to the chat where the job was created.
 
 ### Voice Message Transcription
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ fastapi = "^0.115.0"
 uvicorn = {version = "^0.34.0", extras = ["standard"]}
 apscheduler = "^3.10"
 PyYAML = "^6.0.2"
+edge-tts = "^7.2.8"
 mistralai = {version = "^1.0.0", optional = true}
 openai = {version = "^1.0.0", optional = true}
 pyttsx3 = {version = "^2.90", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,11 @@ apscheduler = "^3.10"
 PyYAML = "^6.0.2"
 mistralai = {version = "^1.0.0", optional = true}
 openai = {version = "^1.0.0", optional = true}
+pyttsx3 = {version = "^2.90", optional = true}
 
 [tool.poetry.extras]
 voice = ["mistralai", "openai"]
+tts = ["pyttsx3"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"

--- a/scripts/voice/send-voice-telegram.sh
+++ b/scripts/voice/send-voice-telegram.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Send an OGG file as a Telegram voice message (not document)
+# Usage: send-voice-telegram.sh <ogg_file> <chat_id> [reply_to_message_id]
+# Requires: TELEGRAM_BOT_TOKEN env var
+
+set -euo pipefail
+
+FILE="$1"
+CHAT_ID="$2"
+REPLY_TO="${3:-}"
+
+ARGS=(-s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendVoice"
+  -F "chat_id=${CHAT_ID}"
+  -F "voice=@${FILE}")
+
+[ -n "$REPLY_TO" ] && ARGS+=(-F "reply_to_message_id=${REPLY_TO}")
+
+RESULT=$(curl "${ARGS[@]}" 2>/dev/null)
+OK=$(echo "$RESULT" | jq -r '.ok')
+
+if [ "$OK" = "true" ]; then
+  echo "$RESULT" | jq -r '.result.message_id'
+  rm -f "$FILE"
+else
+  echo "ERROR: $RESULT" >&2
+  exit 1
+fi

--- a/scripts/voice/text-to-voice.sh
+++ b/scripts/voice/text-to-voice.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Convert text to voice using edge-tts + ffmpeg
+# Usage: text-to-voice.sh "text to speak" [output] [voice] [format]
+# format: ogg (default, for Telegram voice) or mp3
+# Output: prints path to generated file
+
+set -euo pipefail
+
+TEXT="$1"
+VOICE="${3:-es-CO-GonzaloNeural}"
+FORMAT="${4:-ogg}"
+
+if [ "$FORMAT" = "mp3" ]; then
+  OUTPUT="${2:-/tmp/tts-reply-$(date +%s).mp3}"
+  edge-tts --voice "$VOICE" --text "$TEXT" --write-media "$OUTPUT" 2>/dev/null
+else
+  OUTPUT="${2:-/tmp/tts-reply-$(date +%s).ogg}"
+  TMPMP3=$(mktemp /tmp/tts-XXXXXX.mp3)
+  trap 'rm -f "$TMPMP3"' EXIT
+  edge-tts --voice "$VOICE" --text "$TEXT" --write-media "$TMPMP3" 2>/dev/null
+  # Convert to OGG opus (required for Telegram voice messages)
+  ffmpeg -y -i "$TMPMP3" -c:a libopus -b:a 64k -ac 1 -ar 48000 -application voip "$OUTPUT" 2>/dev/null
+fi
+
+echo "$OUTPUT"

--- a/scripts/voice/transcribe-voice.sh
+++ b/scripts/voice/transcribe-voice.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Transcribe a voice note (OGG/OPUS) using whisper-cpp
+# Usage: transcribe-voice.sh <input_file> [language]
+# Output: prints transcription to stdout
+
+set -euo pipefail
+
+INPUT="$1"
+LANG="${2:-es}"
+MODEL="${WHISPER_CPP_MODEL_PATH:-$HOME/.local/share/whisper/ggml-medium.bin}"
+WHISPER_BIN="${WHISPER_CPP_BINARY_PATH:-whisper-cli}"
+TMPWAV=$(mktemp /tmp/whisper-XXXXXX.wav)
+
+trap 'rm -f "$TMPWAV"; rm -f "$INPUT"' EXIT
+
+# Convert to WAV 16kHz mono (required by whisper-cpp)
+ffmpeg -y -i "$INPUT" -ar 16000 -ac 1 -c:a pcm_s16le "$TMPWAV" 2>/dev/null
+
+# Transcribe
+"$WHISPER_BIN" -m "$MODEL" -l "$LANG" -nt -f "$TMPWAV" 2>/dev/null

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "skills": {
+    "fastapi": {
+      "source": "fastapi/fastapi",
+      "sourceType": "github",
+      "computedHash": "ee23d5285caf055cf164ff45dd34888d381143564666baacab8aa786f22e413a"
+    },
+    "python-performance-optimization": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "computedHash": "1a7009e7e16fd08c201f4a527a44d4f0d9d1d892b15b92ab3492624b23be22b8"
+    }
+  }
+}

--- a/src/api/github_issues.py
+++ b/src/api/github_issues.py
@@ -1,0 +1,256 @@
+"""GitHub issues webhook handler — automatic SDD trigger.
+
+When GitHub sends an ``issues`` webhook event with ``action: opened`` or
+``action: labeled``, this module filters the payload against the configured
+allow-list and label requirements, then publishes a :class:`ScheduledEvent`
+that carries an SDD prompt into the event bus.
+
+The existing AgentHandler + NotificationService pipeline picks the event up
+and delivers the Claude response to the configured Telegram chat IDs — no new
+infrastructure needed.
+
+Design decisions
+----------------
+- Filtering logic lives here (not in ``server.py``) so it can be unit-tested
+  without starting an HTTP server.
+- This module is *intentionally* not async — all filtering is pure logic.
+  The async helper at the bottom is what the server calls.
+- We reuse :func:`src.bot.handlers.sdd_handler._build_sdd_prompt` for the
+  prompt text so the behaviour is identical to ``/sdd <url>``.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Payload helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_issue_labels(payload: Dict[str, Any]) -> List[str]:
+    """Return the list of label names on the issue in the payload.
+
+    GitHub sends labels as a list of objects under ``payload["issue"]["labels"]``.
+    Each object has at least a ``"name"`` key.
+    """
+    issue = payload.get("issue") or {}
+    raw_labels = issue.get("labels") or []
+    return [lbl.get("name", "") for lbl in raw_labels if isinstance(lbl, dict)]
+
+
+def _get_labeled_label(payload: Dict[str, Any]) -> Optional[str]:
+    """Return the name of the label that was just added in a ``labeled`` event.
+
+    For ``action: labeled`` GitHub puts the single newly-added label object
+    under ``payload["label"]``.  Returns None if the key is missing.
+    """
+    label_obj = payload.get("label")
+    if isinstance(label_obj, dict):
+        return label_obj.get("name")
+    return None
+
+
+def _get_repo_full_name(payload: Dict[str, Any]) -> Optional[str]:
+    """Return ``owner/repo`` from the payload, or None if not present."""
+    repo = payload.get("repository") or {}
+    return repo.get("full_name")
+
+
+def _get_issue_url(payload: Dict[str, Any]) -> Optional[str]:
+    """Return the HTML URL of the issue, or None."""
+    issue = payload.get("issue") or {}
+    return issue.get("html_url")
+
+
+def _get_issue_number(payload: Dict[str, Any]) -> Optional[int]:
+    """Return the issue number as an int, or None."""
+    issue = payload.get("issue") or {}
+    num = issue.get("number")
+    return int(num) if num is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+class IssueWebhookFilter:
+    """Encapsulates all filtering rules for GitHub issue events.
+
+    Instantiate once at startup (or per-request) with the settings values.
+
+    Parameters
+    ----------
+    enabled:
+        Master switch.  When False, :meth:`should_trigger` always returns
+        ``(False, reason)``.
+    require_label:
+        When True, the issue must carry ``target_label``.
+    target_label:
+        The GitHub label name that activates analysis.
+    repo_allowlist:
+        ``owner/repo`` strings that are allowed.  An empty list means *all*
+        repos are allowed.
+    """
+
+    def __init__(
+        self,
+        enabled: bool,
+        require_label: bool,
+        target_label: str,
+        repo_allowlist: List[str],
+    ) -> None:
+        self.enabled = enabled
+        self.require_label = require_label
+        self.target_label = target_label
+        # Normalise to lower-case for case-insensitive comparison
+        self.repo_allowlist = [r.lower() for r in repo_allowlist]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def should_trigger(
+        self,
+        event_type: str,
+        payload: Dict[str, Any],
+    ) -> tuple[bool, str]:
+        """Decide whether to trigger SDD analysis for this webhook event.
+
+        Returns a ``(should_trigger: bool, reason: str)`` tuple.  The reason
+        is useful for structured logging.
+        """
+        if not self.enabled:
+            return False, "issue_webhook disabled"
+
+        if event_type != "issues":
+            return False, f"event_type={event_type!r} is not 'issues'"
+
+        action = payload.get("action", "")
+        if action not in ("opened", "labeled"):
+            return False, f"action={action!r} not in ('opened', 'labeled')"
+
+        # Repo allowlist check
+        repo = _get_repo_full_name(payload)
+        if self.repo_allowlist:
+            if not repo or repo.lower() not in self.repo_allowlist:
+                return False, f"repo={repo!r} not in allowlist"
+
+        # Label check
+        if self.require_label:
+            ok, reason = self._check_label(action, payload)
+            if not ok:
+                return False, reason
+
+        return True, "ok"
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _check_label(
+        self, action: str, payload: Dict[str, Any]
+    ) -> tuple[bool, str]:
+        """Verify that the required label is present.
+
+        - For ``opened``: the label must already be on the issue.
+        - For ``labeled``: the label that was just added must be the target.
+        """
+        if action == "labeled":
+            added_label = _get_labeled_label(payload)
+            if added_label != self.target_label:
+                return (
+                    False,
+                    f"labeled action but added label={added_label!r} != {self.target_label!r}",
+                )
+            return True, "label match (labeled action)"
+
+        # action == "opened"
+        labels = _get_issue_labels(payload)
+        if self.target_label not in labels:
+            return (
+                False,
+                f"opened action but label {self.target_label!r} not on issue",
+            )
+        return True, "label match (opened action)"
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+
+def build_issue_sdd_prompt(
+    payload: Dict[str, Any],
+    working_directory: Path,
+    protected_branches: List[str],
+) -> str:
+    """Build the SDD prompt for an auto-triggered issue analysis.
+
+    Delegates to :func:`src.bot.handlers.sdd_handler._build_sdd_prompt` so the
+    prompt is identical to what ``/sdd <url>`` would produce.
+
+    Falls back to a minimal inline prompt if the issue URL cannot be extracted
+    (e.g. malformed payload).
+    """
+    from ..bot.handlers.sdd_handler import _build_sdd_prompt
+
+    issue_url = _get_issue_url(payload)
+    if issue_url:
+        return _build_sdd_prompt(
+            arg=issue_url,
+            working_dir=working_directory,
+            protected_branches=protected_branches,
+            is_url=True,
+        )
+
+    # Fallback — describe the event inline
+    issue_number = _get_issue_number(payload)
+    repo = _get_repo_full_name(payload) or "unknown/repo"
+    issue = payload.get("issue") or {}
+    title = issue.get("title", "(no title)")
+    body = issue.get("body", "(no body)") or "(no body)"
+
+    fallback_description = (
+        f"GitHub issue #{issue_number} in {repo}\nTitle: {title}\n\n{body[:500]}"
+    )
+    return _build_sdd_prompt(
+        arg=fallback_description,
+        working_dir=working_directory,
+        protected_branches=protected_branches,
+        is_url=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notification text
+# ---------------------------------------------------------------------------
+
+
+def build_trigger_notification(payload: Dict[str, Any]) -> str:
+    """Return a short Telegram HTML notification sent *before* Claude runs.
+
+    This tells the user that an automatic analysis has started so they know
+    it didn't come out of nowhere.
+    """
+    issue = payload.get("issue") or {}
+    repo = _get_repo_full_name(payload) or "unknown/repo"
+    number = issue.get("number", "?")
+    title = issue.get("title", "(no title)")
+    url = issue.get("html_url", "")
+
+    url_part = f'\n<a href="{url}">View issue</a>' if url else ""
+
+    return (
+        f"🔍 <b>SDD auto-analysis started</b>\n\n"
+        f"GitHub issue <b>#{number}</b> in <code>{repo}</code> triggered an "
+        f"automatic pre-analysis.\n\n"
+        f"<b>{title}</b>{url_part}\n\n"
+        f"Claude is analyzing the issue and will create a branch with the "
+        f"pre-analysis documents. This may take a minute…"
+    )

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -5,16 +5,22 @@ Receives external webhooks and publishes them as events on the bus.
 """
 
 import uuid
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import structlog
 from fastapi import FastAPI, Header, HTTPException, Request
 
 from ..config.settings import Settings
 from ..events.bus import EventBus
-from ..events.types import WebhookEvent
+from ..events.types import AgentResponseEvent, ScheduledEvent, WebhookEvent
 from ..storage.database import DatabaseManager
 from .auth import verify_github_signature, verify_shared_secret
+from .github_issues import (
+    IssueWebhookFilter,
+    build_issue_sdd_prompt,
+    build_trigger_notification,
+)
 
 logger = structlog.get_logger()
 
@@ -23,8 +29,41 @@ def create_api_app(
     event_bus: EventBus,
     settings: Settings,
     db_manager: Optional[DatabaseManager] = None,
+    working_directory: Optional[Path] = None,
+    notification_chat_ids: Optional[List[int]] = None,
 ) -> FastAPI:
-    """Create the FastAPI application."""
+    """Create the FastAPI application.
+
+    Parameters
+    ----------
+    event_bus:
+        The shared async event bus.
+    settings:
+        Application settings.
+    db_manager:
+        Optional database manager for webhook deduplication.
+    working_directory:
+        Directory passed to Claude when auto-triggering SDD analysis for
+        issue webhooks.  Defaults to ``settings.approved_directory``.
+    notification_chat_ids:
+        Telegram chat IDs to notify when an issue SDD analysis is triggered.
+        Falls back to ``settings.notification_chat_ids`` when None.
+    """
+    _working_directory: Path = working_directory or Path(
+        getattr(settings, "approved_directory", "/tmp")
+    )
+    _chat_ids: List[int] = (
+        notification_chat_ids
+        if notification_chat_ids is not None
+        else (settings.notification_chat_ids or [])
+    )
+
+    issue_filter = IssueWebhookFilter(
+        enabled=settings.enable_issue_webhook,
+        require_label=settings.issue_webhook_require_label,
+        target_label=settings.issue_webhook_label,
+        repo_allowlist=settings.issue_webhook_repo_allowlist,
+    )
 
     app = FastAPI(
         title="Claude Code Telegram - Webhook API",
@@ -128,9 +167,94 @@ def create_api_app(
             event_id=event.id,
         )
 
+        # -- GitHub issues: auto-trigger SDD analysis --
+        if provider == "github":
+            await _maybe_trigger_issue_sdd(
+                event_bus=event_bus,
+                event_type=event_type_name,
+                payload=payload,
+                issue_filter=issue_filter,
+                working_directory=_working_directory,
+                protected_branches=getattr(settings, "sdd_protected_branches", []),
+                chat_ids=_chat_ids,
+                originating_event_id=event.id,
+            )
+
         return {"status": "accepted", "event_id": event.id}
 
     return app
+
+
+async def _maybe_trigger_issue_sdd(
+    event_bus: EventBus,
+    event_type: str,
+    payload: Dict[str, Any],
+    issue_filter: IssueWebhookFilter,
+    working_directory: Path,
+    protected_branches: List[str],
+    chat_ids: List[int],
+    originating_event_id: str,
+) -> None:
+    """Apply filtering and, if the issue qualifies, publish a ScheduledEvent.
+
+    The ScheduledEvent carries a fully-formed SDD prompt.  The existing
+    AgentHandler picks it up and runs Claude, then publishes an
+    AgentResponseEvent that NotificationService delivers to the chat IDs.
+
+    A lightweight notification is also sent *before* Claude starts so the
+    user knows the analysis is in progress.
+    """
+    should_run, reason = issue_filter.should_trigger(event_type, payload)
+    logger.info(
+        "GitHub issue webhook filter result",
+        should_trigger=should_run,
+        reason=reason,
+        event_type=event_type,
+        action=payload.get("action"),
+    )
+    if not should_run:
+        return
+
+    issue_number = (payload.get("issue") or {}).get("number", "?")
+    repo = (payload.get("repository") or {}).get("full_name", "unknown/repo")
+
+    # 1. Send an immediate "analysis started" notification
+    if chat_ids:
+        notification_text = build_trigger_notification(payload)
+        for chat_id in chat_ids:
+            await event_bus.publish(
+                AgentResponseEvent(
+                    chat_id=chat_id,
+                    text=notification_text,
+                    parse_mode="HTML",
+                    originating_event_id=originating_event_id,
+                )
+            )
+
+    # 2. Build the SDD prompt and publish as a ScheduledEvent so AgentHandler
+    #    picks it up and runs Claude.
+    prompt = build_issue_sdd_prompt(
+        payload=payload,
+        working_directory=working_directory,
+        protected_branches=protected_branches,
+    )
+
+    await event_bus.publish(
+        ScheduledEvent(
+            job_id=f"issue-webhook-{repo}-{issue_number}",
+            job_name="github_issue_sdd",
+            prompt=prompt,
+            working_directory=working_directory,
+            target_chat_ids=chat_ids,
+        )
+    )
+
+    logger.info(
+        "SDD analysis triggered from GitHub issue webhook",
+        repo=repo,
+        issue_number=issue_number,
+        chat_ids=chat_ids,
+    )
 
 
 async def _try_record_webhook(

--- a/src/bot/features/__init__.py
+++ b/src/bot/features/__init__.py
@@ -2,7 +2,7 @@
 
 from .conversation_mode import ConversationContext, ConversationEnhancer
 from .file_handler import CodebaseAnalysis, FileHandler, ProcessedFile
-from .voice_handler import ProcessedVoice, VoiceHandler
+from .voice_handler import ProcessedVoice, VoiceHandler, VoiceSender
 
 __all__ = [
     "FileHandler",
@@ -12,4 +12,5 @@ __all__ = [
     "ConversationContext",
     "VoiceHandler",
     "ProcessedVoice",
+    "VoiceSender",
 ]

--- a/src/bot/features/git_integration.py
+++ b/src/bot/features/git_integration.py
@@ -144,6 +144,71 @@ class GitIntegration:
             logger.error(f"Git command error: {e}")
             raise GitError(f"Failed to execute git command: {e}")
 
+    async def clone_repo(
+        self,
+        url: str,
+        dest: Path,
+        timeout: int = 120,
+    ) -> None:
+        """Clone a git repository to dest within the approved directory.
+
+        Args:
+            url: Repository URL (must use https://, git://, ssh://, or git@ scheme)
+            dest: Destination path (must be within approved_directory)
+            timeout: Maximum seconds to wait for the clone operation
+
+        Raises:
+            GitError: If URL scheme is invalid, dest is outside approved_directory,
+                      clone times out, or git exits with a non-zero return code
+        """
+        # Validate URL scheme
+        valid_prefixes = ("https://", "git://", "ssh://", "git@")
+        if not any(url.startswith(prefix) for prefix in valid_prefixes):
+            raise GitError(
+                "Invalid URL scheme: only https, ssh and git@ are allowed"
+            )
+
+        # Validate destination is within approved directory
+        try:
+            dest_resolved = dest.resolve()
+            dest_resolved.relative_to(self.approved_dir.resolve())
+        except ValueError:
+            raise GitError("Destination outside approved directory")
+
+        # Execute git clone
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "git",
+                "clone",
+                url,
+                str(dest_resolved),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout
+                )
+            except asyncio.TimeoutError:
+                try:
+                    process.kill()
+                    await process.communicate()
+                except Exception:
+                    pass
+                raise GitError("Clone timed out")
+
+            if process.returncode != 0:
+                raise GitError(
+                    f"Git clone failed: {stderr.decode(errors='replace').strip()}"
+                )
+
+        except GitError:
+            raise
+        except Exception as e:
+            logger.error(f"Git clone error: {e}")
+            raise GitError(f"Failed to clone repository: {e}")
+
     async def get_status(self, repo_path: Path) -> GitStatus:
         """Get repository status.
 

--- a/src/bot/features/registry.py
+++ b/src/bot/features/registry.py
@@ -16,7 +16,7 @@ from .git_integration import GitIntegration
 from .image_handler import ImageHandler
 from .quick_actions import QuickActionManager
 from .session_export import SessionExporter
-from .voice_handler import VoiceHandler
+from .voice_handler import VoiceHandler, VoiceSender
 
 logger = structlog.get_logger(__name__)
 
@@ -91,6 +91,14 @@ class FeatureRegistry:
             except Exception as e:
                 logger.error("Failed to initialize voice handler", error=str(e))
 
+        # Voice TTS replies — independent from STT; only needs edge-tts binary
+        if self.config.enable_voice_replies:
+            try:
+                self.features["voice_sender"] = VoiceSender(config=self.config)
+                logger.info("Voice sender (TTS) feature enabled")
+            except Exception as e:
+                logger.error("Failed to initialize voice sender", error=str(e))
+
         # Conversation enhancements - skip in agentic mode
         if not self.config.agentic_mode:
             try:
@@ -135,6 +143,10 @@ class FeatureRegistry:
     def get_voice_handler(self) -> Optional[VoiceHandler]:
         """Get voice handler feature"""
         return self.get_feature("voice_handler")
+
+    def get_voice_sender(self) -> Optional[VoiceSender]:
+        """Get voice sender (TTS) feature"""
+        return self.get_feature("voice_sender")
 
     def get_conversation_enhancer(self) -> Optional[ConversationEnhancer]:
         """Get conversation enhancer feature"""

--- a/src/bot/features/registry.py
+++ b/src/bot/features/registry.py
@@ -21,6 +21,16 @@ from .voice_handler import VoiceHandler, VoiceSender
 logger = structlog.get_logger(__name__)
 
 
+def _pyttsx3_importable() -> bool:
+    """Return True if pyttsx3 can be imported (i.e. it is installed)."""
+    try:
+        import pyttsx3  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 class FeatureRegistry:
     """Manage all bot features"""
 
@@ -91,13 +101,45 @@ class FeatureRegistry:
             except Exception as e:
                 logger.error("Failed to initialize voice handler", error=str(e))
 
-        # Voice TTS replies — independent from STT; only needs edge-tts binary
+        # Voice TTS replies — engine-specific availability check before construction
         if self.config.enable_voice_replies:
-            try:
-                self.features["voice_sender"] = VoiceSender(config=self.config)
-                logger.info("Voice sender (TTS) feature enabled")
-            except Exception as e:
-                logger.error("Failed to initialize voice sender", error=str(e))
+            tts_available: bool
+            tts_skip_reason: str = ""
+            if self.config.tts_engine == "openai":
+                if self.config.openai_api_key:
+                    tts_available = True
+                else:
+                    tts_available = False
+                    tts_skip_reason = (
+                        "OPENAI_API_KEY is not set (required for tts_engine=openai)"
+                    )
+            elif self.config.tts_engine == "system":
+                if _pyttsx3_importable():
+                    tts_available = True
+                else:
+                    tts_available = False
+                    tts_skip_reason = (
+                        "pyttsx3 is not installed (required for tts_engine=system). "
+                        'Install with: pip install "claude-code-telegram[tts]"'
+                    )
+            else:  # edge-tts — binary checked lazily at call time
+                tts_available = True
+
+            if tts_available:
+                try:
+                    self.features["voice_sender"] = VoiceSender(config=self.config)
+                    logger.info(
+                        "Voice sender (TTS) feature enabled",
+                        engine=self.config.tts_engine,
+                    )
+                except Exception as e:
+                    logger.error("Failed to initialize voice sender", error=str(e))
+            else:
+                logger.warning(
+                    "Voice sender (TTS) disabled — engine dependency unavailable",
+                    engine=self.config.tts_engine,
+                    reason=tts_skip_reason,
+                )
 
         # Conversation enhancements - skip in agentic mode
         if not self.config.agentic_mode:

--- a/src/bot/features/voice_handler.py
+++ b/src/bot/features/voice_handler.py
@@ -297,7 +297,7 @@ class VoiceHandler:
                 str(wav_path),
                 "--no-timestamps",
                 "-l",
-                "auto",
+                self.config.whisper_cpp_language,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/bot/features/voice_handler.py
+++ b/src/bot/features/voice_handler.py
@@ -353,19 +353,47 @@ class VoiceHandler:
 
 
 class VoiceSender:
-    """Synthesize outgoing voice replies using edge-tts and send via Telegram sendVoice.
+    """Synthesize outgoing voice replies using a configurable TTS engine.
 
     Complementary to VoiceHandler (STT) — this class handles TTS (text-to-speech).
-    Requires the ``edge-tts`` CLI binary on PATH (``pip install edge-tts``).
+    Supported engines (VOICE_ENGINE env var):
+    - ``edge-tts`` (default): requires the edge-tts CLI binary on PATH
+    - ``openai``: requires OPENAI_API_KEY and ffmpeg
+    - ``system``: requires pyttsx3 (``pip install pyttsx3``) and ffmpeg
     """
 
-    # Maximum seconds to wait for the edge-tts subprocess.
+    # Maximum seconds to wait for TTS subprocess operations.
     TTS_SUBPROCESS_TIMEOUT: int = 60
 
     def __init__(self, config: Settings) -> None:
         self.config = config
+        self._openai_client: Optional[Any] = None
+
+    # -- Dispatcher --
 
     async def _synthesize_ogg(self, text: str, tmp_dir: Path) -> Path:
+        """Dispatch to the configured TTS engine and return an OGG/Opus file path.
+
+        Args:
+            text: The text to synthesize.
+            tmp_dir: Temporary directory for output files.
+
+        Returns:
+            Path to the generated OGG file.
+
+        Raises:
+            RuntimeError: On subprocess failure, timeout, missing binary/dep, or bad config.
+        """
+        if self.config.tts_engine == "openai":
+            return await self._synthesize_ogg_openai(text, tmp_dir)
+        elif self.config.tts_engine == "system":
+            return await self._synthesize_ogg_system(text, tmp_dir)
+        else:  # "edge-tts" default
+            return await self._synthesize_ogg_edge_tts(text, tmp_dir)
+
+    # -- edge-tts engine --
+
+    async def _synthesize_ogg_edge_tts(self, text: str, tmp_dir: Path) -> Path:
         """Run edge-tts to synthesize OGG/Opus audio from text.
 
         Args:
@@ -419,6 +447,161 @@ class VoiceSender:
 
         return ogg_path
 
+    # -- OpenAI engine --
+
+    def _get_openai_tts_client(self) -> Any:
+        """Create and cache an AsyncOpenAI client for TTS on first use."""
+        if self._openai_client is not None:
+            return self._openai_client
+
+        try:
+            from openai import AsyncOpenAI
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Optional dependency 'openai' is missing for TTS. "
+                "Install voice extras: "
+                'pip install "claude-code-telegram[voice]"'
+            ) from exc
+
+        api_key = self.config.openai_api_key_str
+        if not api_key:
+            raise RuntimeError(
+                "OpenAI API key is not configured. "
+                "Set OPENAI_API_KEY to use the openai TTS engine."
+            )
+
+        self._openai_client = AsyncOpenAI(api_key=api_key)
+        return self._openai_client
+
+    async def _synthesize_ogg_openai(self, text: str, tmp_dir: Path) -> Path:
+        """Synthesize audio via OpenAI TTS API, convert to OGG/Opus via ffmpeg.
+
+        Args:
+            text: The text to synthesize.
+            tmp_dir: Temporary directory for intermediate and output files.
+
+        Returns:
+            Path to the generated OGG file.
+
+        Raises:
+            RuntimeError: On API failure, ffmpeg missing/failure, or missing API key.
+        """
+        client = self._get_openai_tts_client()
+
+        try:
+            response = await client.audio.speech.create(
+                model="tts-1",
+                voice=self.config.openai_tts_voice,
+                input=text,
+            )
+        except Exception as exc:
+            logger.warning(
+                "OpenAI TTS request failed",
+                error_type=type(exc).__name__,
+            )
+            raise RuntimeError("OpenAI TTS request failed.") from exc
+
+        mp3_path = tmp_dir / "reply.mp3"
+        mp3_path.write_bytes(response.content)
+
+        ogg_path = tmp_dir / "reply.ogg"
+        await self._ffmpeg_convert(mp3_path, ogg_path)
+        return ogg_path
+
+    # -- System (pyttsx3) engine --
+
+    async def _synthesize_ogg_system(self, text: str, tmp_dir: Path) -> Path:
+        """Synthesize audio via pyttsx3 (offline), convert to OGG/Opus via ffmpeg.
+
+        pyttsx3.runAndWait() is synchronous — it is wrapped in asyncio.to_thread()
+        to avoid blocking the event loop.
+
+        Args:
+            text: The text to synthesize.
+            tmp_dir: Temporary directory for intermediate and output files.
+
+        Returns:
+            Path to the generated OGG file.
+
+        Raises:
+            RuntimeError: On pyttsx3 missing, ffmpeg missing/failure.
+        """
+        try:
+            import pyttsx3
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Optional dependency 'pyttsx3' is missing for system TTS. "
+                "Install it with: "
+                'pip install "claude-code-telegram[tts]" or pip install pyttsx3'
+            ) from exc
+
+        wav_path = tmp_dir / "reply.wav"
+        voice_id: Optional[str] = (
+            self.config.system_tts_voice
+            if self.config.system_tts_voice != "default"
+            else None
+        )
+
+        def _run_pyttsx3() -> None:
+            engine = pyttsx3.init()
+            if voice_id is not None:
+                engine.setProperty("voice", voice_id)
+            engine.save_to_file(text, str(wav_path))
+            engine.runAndWait()
+
+        await asyncio.to_thread(_run_pyttsx3)
+
+        ogg_path = tmp_dir / "reply.ogg"
+        await self._ffmpeg_convert(wav_path, ogg_path)
+        return ogg_path
+
+    # -- Shared ffmpeg helper --
+
+    async def _ffmpeg_convert(self, input_path: Path, output_path: Path) -> None:
+        """Convert an audio file to OGG/Opus using ffmpeg.
+
+        Args:
+            input_path: Source audio file (MP3, WAV, etc.).
+            output_path: Destination OGG/Opus file.
+
+        Raises:
+            RuntimeError: On ffmpeg missing, non-zero exit, or timeout.
+        """
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "ffmpeg",
+                "-i",
+                str(input_path),
+                "-c:a",
+                "libopus",
+                str(output_path),
+                "-y",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=self.TTS_SUBPROCESS_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                raise RuntimeError(
+                    f"ffmpeg conversion timed out after {self.TTS_SUBPROCESS_TIMEOUT}s."
+                )
+
+            if process.returncode != 0:
+                err_msg = stderr.decode(errors="replace")[:300] if stderr else ""
+                raise RuntimeError(
+                    f"ffmpeg conversion failed (exit {process.returncode}): {err_msg}"
+                )
+
+        except FileNotFoundError:
+            raise RuntimeError(
+                "ffmpeg is required for audio conversion but was not found on PATH. "
+                "Install it with: apt install ffmpeg  (or brew install ffmpeg on macOS)"
+            )
+
     async def send_voice_reply(
         self,
         text: str,
@@ -427,8 +610,8 @@ class VoiceSender:
     ) -> bool:
         """Synthesize text as OGG audio and send via Telegram sendVoice.
 
-        Creates a temp directory, synthesizes OGG via edge-tts, sends it,
-        and always cleans up the temp dir (even on failure).
+        Creates a temp directory, synthesizes OGG via the configured TTS engine,
+        sends it, and always cleans up the temp dir (even on failure).
 
         Args:
             text: The text to convert to speech.
@@ -452,7 +635,7 @@ class VoiceSender:
 
             logger.info(
                 "Voice reply sent",
-                voice=self.config.edge_tts_voice,
+                engine=self.config.tts_engine,
                 word_count=len(text.split()),
             )
             return True

--- a/src/bot/features/voice_handler.py
+++ b/src/bot/features/voice_handler.py
@@ -1,4 +1,7 @@
-"""Handle voice message transcription via Mistral (Voxtral), OpenAI (Whisper), or local whisper.cpp."""
+"""Handle voice message transcription via Mistral (Voxtral), OpenAI (Whisper), or local whisper.cpp.
+
+Also provides VoiceSender for outgoing TTS voice replies via edge-tts.
+"""
 
 import asyncio
 import shutil
@@ -9,7 +12,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import structlog
-from telegram import Voice
+from telegram import Update, Voice
 
 from src.config.settings import Settings
 
@@ -347,3 +350,121 @@ class VoiceHandler:
             )
         self._resolved_whisper_binary = resolved
         return resolved
+
+
+class VoiceSender:
+    """Synthesize outgoing voice replies using edge-tts and send via Telegram sendVoice.
+
+    Complementary to VoiceHandler (STT) — this class handles TTS (text-to-speech).
+    Requires the ``edge-tts`` CLI binary on PATH (``pip install edge-tts``).
+    """
+
+    # Maximum seconds to wait for the edge-tts subprocess.
+    TTS_SUBPROCESS_TIMEOUT: int = 60
+
+    def __init__(self, config: Settings) -> None:
+        self.config = config
+
+    async def _synthesize_ogg(self, text: str, tmp_dir: Path) -> Path:
+        """Run edge-tts to synthesize OGG/Opus audio from text.
+
+        Args:
+            text: The text to synthesize.
+            tmp_dir: Temporary directory for the output file.
+
+        Returns:
+            Path to the generated OGG file.
+
+        Raises:
+            RuntimeError: On subprocess failure, timeout, or missing binary.
+        """
+        ogg_path = tmp_dir / "reply.ogg"
+        voice = self.config.edge_tts_voice
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "edge-tts",
+                "--voice",
+                voice,
+                "--text",
+                text,
+                "--write-media",
+                str(ogg_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=self.TTS_SUBPROCESS_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                raise RuntimeError(
+                    f"edge-tts synthesis timed out after {self.TTS_SUBPROCESS_TIMEOUT}s."
+                )
+
+            if process.returncode != 0:
+                err_msg = stderr.decode(errors="replace")[:300] if stderr else ""
+                raise RuntimeError(
+                    f"edge-tts synthesis failed (exit {process.returncode}): {err_msg}"
+                )
+
+        except FileNotFoundError:
+            raise RuntimeError(
+                "edge-tts binary not found on PATH. "
+                "Install it with: pip install edge-tts"
+            )
+
+        return ogg_path
+
+    async def send_voice_reply(
+        self,
+        text: str,
+        update: Update,
+        reply_to_message_id: Optional[int] = None,
+    ) -> bool:
+        """Synthesize text as OGG audio and send via Telegram sendVoice.
+
+        Creates a temp directory, synthesizes OGG via edge-tts, sends it,
+        and always cleans up the temp dir (even on failure).
+
+        Args:
+            text: The text to convert to speech.
+            update: The Telegram Update to reply to.
+            reply_to_message_id: Optional message ID to reply to.
+
+        Returns:
+            True on success, False if any step failed.
+        """
+        tmp_dir: Optional[Path] = None
+        try:
+            tmp_dir = Path(tempfile.mkdtemp(prefix="tts_"))
+
+            ogg_path = await self._synthesize_ogg(text, tmp_dir)
+
+            with open(ogg_path, "rb") as audio_file:
+                await update.message.reply_voice(
+                    voice=audio_file,
+                    reply_to_message_id=reply_to_message_id,
+                )
+
+            logger.info(
+                "Voice reply sent",
+                voice=self.config.edge_tts_voice,
+                word_count=len(text.split()),
+            )
+            return True
+
+        except Exception as exc:
+            logger.warning(
+                "Voice reply failed, falling back to text",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            return False
+
+        finally:
+            if tmp_dir is not None:
+                shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/bot/features/voice_handler.py
+++ b/src/bot/features/voice_handler.py
@@ -371,12 +371,15 @@ class VoiceSender:
 
     # -- Dispatcher --
 
-    async def _synthesize_ogg(self, text: str, tmp_dir: Path) -> Path:
+    async def _synthesize_ogg(
+        self, text: str, tmp_dir: Path, voice_override: Optional[str] = None
+    ) -> Path:
         """Dispatch to the configured TTS engine and return an OGG/Opus file path.
 
         Args:
             text: The text to synthesize.
             tmp_dir: Temporary directory for output files.
+            voice_override: Override the configured voice name (edge-tts only).
 
         Returns:
             Path to the generated OGG file.
@@ -389,62 +392,52 @@ class VoiceSender:
         elif self.config.tts_engine == "system":
             return await self._synthesize_ogg_system(text, tmp_dir)
         else:  # "edge-tts" default
-            return await self._synthesize_ogg_edge_tts(text, tmp_dir)
+            return await self._synthesize_ogg_edge_tts(text, tmp_dir, voice_override=voice_override)
 
     # -- edge-tts engine --
 
-    async def _synthesize_ogg_edge_tts(self, text: str, tmp_dir: Path) -> Path:
-        """Run edge-tts to synthesize OGG/Opus audio from text.
+    async def _synthesize_ogg_edge_tts(
+        self, text: str, tmp_dir: Path, voice_override: Optional[str] = None
+    ) -> Path:
+        """Synthesize OGG/Opus audio via the edge_tts Python API (no subprocess needed).
 
         Args:
             text: The text to synthesize.
             tmp_dir: Temporary directory for the output file.
+            voice_override: Use this voice instead of the configured default.
 
         Returns:
             Path to the generated OGG file.
 
         Raises:
-            RuntimeError: On subprocess failure, timeout, or missing binary.
+            RuntimeError: On synthesis failure or missing dependency.
         """
-        ogg_path = tmp_dir / "reply.ogg"
-        voice = self.config.edge_tts_voice
+        try:
+            import edge_tts
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Optional dependency 'edge-tts' is missing. "
+                "Install it with: pip install edge-tts"
+            ) from exc
+
+        voice = voice_override or self.config.edge_tts_voice
+        mp3_path = tmp_dir / "reply.mp3"
 
         try:
-            process = await asyncio.create_subprocess_exec(
-                "edge-tts",
-                "--voice",
-                voice,
-                "--text",
-                text,
-                "--write-media",
-                str(ogg_path),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            communicate = edge_tts.Communicate(text, voice)
+            await asyncio.wait_for(
+                communicate.save(str(mp3_path)),
+                timeout=self.TTS_SUBPROCESS_TIMEOUT,
             )
-
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    process.communicate(),
-                    timeout=self.TTS_SUBPROCESS_TIMEOUT,
-                )
-            except asyncio.TimeoutError:
-                process.kill()
-                raise RuntimeError(
-                    f"edge-tts synthesis timed out after {self.TTS_SUBPROCESS_TIMEOUT}s."
-                )
-
-            if process.returncode != 0:
-                err_msg = stderr.decode(errors="replace")[:300] if stderr else ""
-                raise RuntimeError(
-                    f"edge-tts synthesis failed (exit {process.returncode}): {err_msg}"
-                )
-
-        except FileNotFoundError:
+        except asyncio.TimeoutError:
             raise RuntimeError(
-                "edge-tts binary not found on PATH. "
-                "Install it with: pip install edge-tts"
+                f"edge-tts synthesis timed out after {self.TTS_SUBPROCESS_TIMEOUT}s."
             )
+        except Exception as exc:
+            raise RuntimeError(f"edge-tts synthesis failed: {exc}") from exc
 
+        ogg_path = tmp_dir / "reply.ogg"
+        await self._ffmpeg_convert(mp3_path, ogg_path)
         return ogg_path
 
     # -- OpenAI engine --
@@ -607,6 +600,7 @@ class VoiceSender:
         text: str,
         update: Update,
         reply_to_message_id: Optional[int] = None,
+        voice_override: Optional[str] = None,
     ) -> bool:
         """Synthesize text as OGG audio and send via Telegram sendVoice.
 
@@ -617,6 +611,7 @@ class VoiceSender:
             text: The text to convert to speech.
             update: The Telegram Update to reply to.
             reply_to_message_id: Optional message ID to reply to.
+            voice_override: Override the configured voice name (edge-tts only).
 
         Returns:
             True on success, False if any step failed.
@@ -625,7 +620,7 @@ class VoiceSender:
         try:
             tmp_dir = Path(tempfile.mkdtemp(prefix="tts_"))
 
-            ogg_path = await self._synthesize_ogg(text, tmp_dir)
+            ogg_path = await self._synthesize_ogg(text, tmp_dir, voice_override=voice_override)
 
             with open(ogg_path, "rb") as audio_file:
                 await update.message.reply_voice(

--- a/src/bot/handlers/callback.py
+++ b/src/bot/handlers/callback.py
@@ -57,6 +57,11 @@ async def handle_callback_query(
             action, param = data, None
 
         # Route to appropriate handler
+        from .command import _handle_model_selection
+
+        async def _model_effort_handler(query, param, context):
+            await _handle_model_selection(query, f"{action}:{param}", context)
+
         handlers = {
             "cd": handle_cd_callback,
             "action": handle_action_callback,
@@ -66,6 +71,8 @@ async def handle_callback_query(
             "conversation": handle_conversation_callback,
             "git": handle_git_callback,
             "export": handle_export_callback,
+            "model": _model_effort_handler,
+            "effort": _model_effort_handler,
         }
 
         handler = handlers.get(action)

--- a/src/bot/handlers/callback.py
+++ b/src/bot/handlers/callback.py
@@ -12,6 +12,7 @@ from ...config.settings import Settings
 from ...security.audit import AuditLogger
 from ...security.validators import SecurityValidator
 from ..utils.html_format import escape_html
+from .command import _handle_model_selection
 
 logger = structlog.get_logger()
 
@@ -57,11 +58,6 @@ async def handle_callback_query(
             action, param = data, None
 
         # Route to appropriate handler
-        from .command import _handle_model_selection
-
-        async def _model_effort_handler(query, param, context):
-            await _handle_model_selection(query, f"{action}:{param}", context)
-
         handlers = {
             "cd": handle_cd_callback,
             "action": handle_action_callback,
@@ -71,8 +67,8 @@ async def handle_callback_query(
             "conversation": handle_conversation_callback,
             "git": handle_git_callback,
             "export": handle_export_callback,
-            "model": _model_effort_handler,
-            "effort": _model_effort_handler,
+            "model": lambda q, p, ctx: _handle_model_selection(q, f"model:{p}", ctx),
+            "effort": lambda q, p, ctx: _handle_model_selection(q, f"effort:{p}", ctx),
         }
 
         handler = handlers.get(action)

--- a/src/bot/handlers/command.py
+++ b/src/bot/handlers/command.py
@@ -174,7 +174,8 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "• <code>/status</code> - Show session and usage status\n"
         "• <code>/export</code> - Export session history\n"
         "• <code>/actions</code> - Show context-aware quick actions\n"
-        "• <code>/git</code> - Git repository information\n\n"
+        "• <code>/git</code> - Git repository information\n"
+        "• <code>/model [name]</code> - View or switch Claude model\n\n"
         "<b>Session Behavior:</b>\n"
         "• Sessions are automatically maintained per project directory\n"
         "• Switching directories with <code>/cd</code> resumes the session for that project\n"
@@ -1230,6 +1231,165 @@ async def git_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     except Exception as e:
         await update.message.reply_text(f"❌ <b>Git Error</b>\n\n{str(e)}")
         logger.error("Error in git_command", error=str(e), user_id=user_id)
+
+
+# Model IDs mapped to user-friendly labels
+_MODELS = {
+    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+
+# Effort levels per model (Haiku doesn't support effort; "max" is Opus-only)
+_EFFORT_BY_MODEL = {
+    "opus": ["low", "medium", "high", "max"],
+    "sonnet": ["low", "medium", "high"],
+    "haiku": [],
+}
+
+
+def _current_model_label(context: ContextTypes.DEFAULT_TYPE) -> str:
+    """Return a human-friendly label for the active model + effort."""
+    override = context.user_data.get("model_override")
+    effort = context.user_data.get("effort_override")
+    # Reverse-map model ID to short name
+    model_id = override or ""
+    label = model_id
+    for short, full in _MODELS.items():
+        if full == model_id:
+            label = short.capitalize()
+            break
+    if not override:
+        label = "Default"
+    parts = [label]
+    if effort:
+        parts.append(f"effort={effort}")
+    return " | ".join(parts)
+
+
+async def model_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /model command - show model selection keyboard."""
+    current = _current_model_label(context)
+
+    keyboard = [
+        [
+            InlineKeyboardButton("Opus", callback_data="model:opus"),
+            InlineKeyboardButton("Sonnet", callback_data="model:sonnet"),
+            InlineKeyboardButton("Haiku", callback_data="model:haiku"),
+        ],
+        [InlineKeyboardButton("Reset to default", callback_data="model:default")],
+    ]
+
+    await update.message.reply_text(
+        f"🤖 <b>Current:</b> {escape_html(current)}\n\n"
+        "Choose a model:\n"
+        "<i>⚠️ Switching will start a new session.</i>",
+        parse_mode="HTML",
+        reply_markup=InlineKeyboardMarkup(keyboard),
+    )
+
+
+async def _handle_model_selection(query, data: str, context) -> None:
+    """Shared logic for model/effort selection (used by both callback routes)."""
+    if data.startswith("model:"):
+        choice = data.split(":", 1)[1]
+
+        if choice == "default":
+            context.user_data.pop("model_override", None)
+            context.user_data.pop("effort_override", None)
+            context.user_data["force_new_session"] = True
+            await query.edit_message_text(
+                "🤖 Model and effort reset to server defaults.\n"
+                "<i>Next message starts a fresh session.</i>",
+                parse_mode="HTML",
+            )
+            logger.info("Model override cleared", user_id=query.from_user.id)
+            return
+
+        model_id = _MODELS.get(choice)
+        if not model_id:
+            await query.edit_message_text("Unknown model.")
+            return
+
+        context.user_data["model_override"] = model_id
+        # Clear stale effort when switching models
+        context.user_data.pop("effort_override", None)
+        # Force new session so the model change takes effect immediately
+        context.user_data["force_new_session"] = True
+
+        logger.info(
+            "Model override set",
+            user_id=query.from_user.id,
+            model=model_id,
+        )
+
+        # Show effort level selection (if supported by this model)
+        effort_levels = _EFFORT_BY_MODEL.get(choice, [])
+        if not effort_levels:
+            # Model doesn't support effort (e.g. Haiku)
+            current = _current_model_label(context)
+            await query.edit_message_text(
+                f"🤖 <b>{escape_html(current)}</b> — ready.\n"
+                "<i>New session will start with your next message.</i>",
+                parse_mode="HTML",
+            )
+            return
+
+        rows = []
+        row = []
+        for level in effort_levels:
+            row.append(
+                InlineKeyboardButton(level.capitalize(), callback_data=f"effort:{level}")
+            )
+            if len(row) == 2:
+                rows.append(row)
+                row = []
+        if row:
+            rows.append(row)
+        rows.append(
+            [InlineKeyboardButton("Skip (keep current)", callback_data="effort:skip")]
+        )
+
+        await query.edit_message_text(
+            f"🤖 Model set to <b>{escape_html(choice.capitalize())}</b>.\n\n"
+            "Choose effort level:",
+            parse_mode="HTML",
+            reply_markup=InlineKeyboardMarkup(rows),
+        )
+
+    elif data.startswith("effort:"):
+        level = data.split(":", 1)[1]
+
+        if level == "skip":
+            current = _current_model_label(context)
+            await query.edit_message_text(
+                f"🤖 <b>{escape_html(current)}</b> — ready.\n"
+                "<i>New session will start with your next message.</i>",
+                parse_mode="HTML",
+            )
+            return
+
+        all_effort_levels = {"low", "medium", "high", "max"}
+        if level in all_effort_levels:
+            context.user_data["effort_override"] = level
+            current = _current_model_label(context)
+            await query.edit_message_text(
+                f"🤖 <b>{escape_html(current)}</b> — ready.\n"
+                "<i>New session will start with your next message.</i>",
+                parse_mode="HTML",
+            )
+            logger.info(
+                "Effort override set",
+                user_id=query.from_user.id,
+                effort=level,
+            )
+
+
+async def model_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle model and effort selection callbacks (agentic mode route)."""
+    query = update.callback_query
+    await query.answer()
+    await _handle_model_selection(query, query.data, context)
 
 
 async def restart_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/bot/handlers/command.py
+++ b/src/bot/handlers/command.py
@@ -1260,7 +1260,9 @@ def _current_model_label(context: ContextTypes.DEFAULT_TYPE) -> str:
             label = short.capitalize()
             break
     if not override:
-        label = "Default"
+        settings = context.bot_data.get("settings")
+        server_model = getattr(settings, "claude_model", None) if settings else None
+        label = f"Default ({server_model or 'CLI default'})"
     parts = [label]
     if effort:
         parts.append(f"effort={effort}")

--- a/src/bot/handlers/command.py
+++ b/src/bot/handlers/command.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 import structlog
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from ...claude.facade import ClaudeIntegration
@@ -1233,14 +1233,13 @@ async def git_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         logger.error("Error in git_command", error=str(e), user_id=user_id)
 
 
-# Model IDs mapped to user-friendly labels
-_MODELS = {
-    "opus": "claude-opus-4-6",
-    "sonnet": "claude-sonnet-4-6",
-    "haiku": "claude-haiku-4-5-20251001",
-}
+# Short CLI aliases passed directly to the Claude CLI, which resolves them to
+# the current latest model of each family. No version numbers to maintain here.
+# See: https://docs.anthropic.com/en/docs/about-claude/models/overview
+_MODEL_FAMILIES = ["opus", "sonnet", "haiku"]
 
-# Effort levels per model (Haiku doesn't support effort; "max" is Opus-only)
+# Effort levels per model family. Haiku has none; "max" is Opus-only.
+# Update here if a future model's effort support changes.
 _EFFORT_BY_MODEL = {
     "opus": ["low", "medium", "high", "max"],
     "sonnet": ["low", "medium", "high"],
@@ -1250,23 +1249,15 @@ _EFFORT_BY_MODEL = {
 
 def _current_model_label(context: ContextTypes.DEFAULT_TYPE) -> str:
     """Return a human-friendly label for the active model + effort."""
-    override = context.user_data.get("model_override")
+    override = context.user_data.get("model_override")  # "opus", "sonnet", "haiku", or None
     effort = context.user_data.get("effort_override")
-    # Reverse-map model ID to short name
-    model_id = override or ""
-    label = model_id
-    for short, full in _MODELS.items():
-        if full == model_id:
-            label = short.capitalize()
-            break
     if not override:
         settings = context.bot_data.get("settings")
         server_model = getattr(settings, "claude_model", None) if settings else None
         label = f"Default ({server_model or 'CLI default'})"
-    parts = [label]
-    if effort:
-        parts.append(f"effort={effort}")
-    return " | ".join(parts)
+    else:
+        label = override.capitalize()
+    return f"{label} | effort={effort}" if effort else label
 
 
 async def model_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1291,7 +1282,11 @@ async def model_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     )
 
 
-async def _handle_model_selection(query, data: str, context) -> None:
+async def _handle_model_selection(
+    query: CallbackQuery,
+    data: str,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
     """Shared logic for model/effort selection (used by both callback routes)."""
     if data.startswith("model:"):
         choice = data.split(":", 1)[1]
@@ -1299,6 +1294,7 @@ async def _handle_model_selection(query, data: str, context) -> None:
         if choice == "default":
             context.user_data.pop("model_override", None)
             context.user_data.pop("effort_override", None)
+            # Note: if PR #165 merges first, change this to context.chat_data
             context.user_data["force_new_session"] = True
             await query.edit_message_text(
                 "🤖 Model and effort reset to server defaults.\n"
@@ -1308,21 +1304,23 @@ async def _handle_model_selection(query, data: str, context) -> None:
             logger.info("Model override cleared", user_id=query.from_user.id)
             return
 
-        model_id = _MODELS.get(choice)
-        if not model_id:
+        if choice not in _MODEL_FAMILIES:
             await query.edit_message_text("Unknown model.")
             return
 
-        context.user_data["model_override"] = model_id
+        # Store short CLI alias ("opus"/"sonnet"/"haiku") — the CLI resolves it
+        # to the current latest model, so no version numbers to maintain.
+        context.user_data["model_override"] = choice
         # Clear stale effort when switching models
         context.user_data.pop("effort_override", None)
         # Force new session so the model change takes effect immediately
+        # Note: if PR #165 merges first, change this to context.chat_data
         context.user_data["force_new_session"] = True
 
         logger.info(
             "Model override set",
             user_id=query.from_user.id,
-            model=model_id,
+            model=choice,
         )
 
         # Show effort level selection (if supported by this model)

--- a/src/bot/handlers/message.py
+++ b/src/bot/handlers/message.py
@@ -393,6 +393,8 @@ async def handle_text_message(
                 session_id=session_id,
                 on_stream=stream_handler,
                 force_new=force_new,
+                model_override=context.user_data.get("model_override"),
+                effort_override=context.user_data.get("effort_override"),
             )
 
             # New session created successfully — clear the one-shot flag
@@ -818,6 +820,8 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 working_directory=current_dir,
                 user_id=user_id,
                 session_id=session_id,
+                model_override=context.user_data.get("model_override"),
+                effort_override=context.user_data.get("effort_override"),
             )
 
             # Update session ID
@@ -945,6 +949,8 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     working_directory=current_dir,
                     user_id=user_id,
                     session_id=session_id,
+                    model_override=context.user_data.get("model_override"),
+                    effort_override=context.user_data.get("effort_override"),
                 )
 
                 # Update session ID
@@ -1073,6 +1079,8 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 working_directory=current_dir,
                 user_id=user_id,
                 session_id=session_id,
+                model_override=context.user_data.get("model_override"),
+                effort_override=context.user_data.get("effort_override"),
             )
 
             context.user_data["claude_session_id"] = claude_response.session_id

--- a/src/bot/handlers/schedule.py
+++ b/src/bot/handlers/schedule.py
@@ -1,0 +1,200 @@
+"""Schedule command handler for managing scheduled jobs via Telegram."""
+
+from typing import List
+
+import structlog
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ...scheduler.scheduler import JobScheduler
+from ..utils.html_format import escape_html
+
+logger = structlog.get_logger()
+
+
+def _get_scheduler(context: ContextTypes.DEFAULT_TYPE) -> JobScheduler | None:
+    """Get the JobScheduler from bot dependencies."""
+    return context.bot_data.get("scheduler")
+
+
+async def schedule_command(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Handle /schedule command with subcommands.
+
+    Usage:
+        /schedule list
+        /schedule add <name> <cron_expr> <prompt>
+        /schedule remove <job_id>
+        /schedule pause <job_id>
+        /schedule resume <job_id>
+    """
+    scheduler = _get_scheduler(context)
+    if not scheduler:
+        await update.message.reply_text(
+            "Scheduler is not enabled. Set ENABLE_SCHEDULER=true to use this command."
+        )
+        return
+
+    args: List[str] = context.args or []
+
+    if not args:
+        await _show_usage(update)
+        return
+
+    subcommand = args[0].lower()
+    sub_args = args[1:]
+
+    if subcommand == "list":
+        await _handle_list(update, scheduler)
+    elif subcommand == "add":
+        await _handle_add(update, context, scheduler, sub_args)
+    elif subcommand == "remove":
+        await _handle_remove(update, scheduler, sub_args)
+    elif subcommand == "pause":
+        await _handle_pause(update, scheduler, sub_args)
+    elif subcommand == "resume":
+        await _handle_resume(update, scheduler, sub_args)
+    else:
+        await _show_usage(update)
+
+
+async def _show_usage(update: Update) -> None:
+    """Show usage information."""
+    await update.message.reply_html(
+        "<b>Usage:</b>\n"
+        "/schedule list\n"
+        "/schedule add &lt;name&gt; &lt;cron&gt; &lt;prompt&gt;\n"
+        "/schedule remove &lt;job_id&gt;\n"
+        "/schedule pause &lt;job_id&gt;\n"
+        "/schedule resume &lt;job_id&gt;\n\n"
+        "<b>Cron format:</b> min hour day month weekday\n"
+        "Example: <code>/schedule add daily-report 0 9 * * * Check status</code>"
+    )
+
+
+async def _handle_list(update: Update, scheduler: JobScheduler) -> None:
+    """List all scheduled jobs."""
+    jobs = await scheduler.list_jobs(include_paused=True)
+
+    if not jobs:
+        await update.message.reply_text("No scheduled jobs.")
+        return
+
+    lines = ["<b>Scheduled Jobs:</b>\n"]
+    for job in jobs:
+        status = "active" if job.get("is_active") else "paused"
+        name = escape_html(job.get("job_name", "?"))
+        cron = escape_html(job.get("cron_expression", "?"))
+        job_id = escape_html(str(job.get("job_id", "?")))
+        lines.append(
+            f"<b>{name}</b> [{status}]\n"
+            f"  Cron: <code>{cron}</code>\n"
+            f"  ID: <code>{job_id}</code>"
+        )
+
+    await update.message.reply_html("\n\n".join(lines))
+
+
+async def _handle_add(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    scheduler: JobScheduler,
+    args: List[str],
+) -> None:
+    """Add a new scheduled job.
+
+    Expected args: <name> <min> <hour> <day> <month> <weekday> <prompt...>
+    The 5 cron fields are joined into a single cron expression.
+    """
+    # Need at least: name + 5 cron fields + 1 prompt word = 7
+    if len(args) < 7:
+        await update.message.reply_html(
+            "<b>Usage:</b> /schedule add &lt;name&gt; "
+            "&lt;min&gt; &lt;hour&gt; &lt;day&gt; &lt;month&gt; &lt;weekday&gt; "
+            "&lt;prompt&gt;\n\n"
+            "Example: <code>/schedule add daily-report 0 9 * * * Check status</code>"
+        )
+        return
+
+    job_name = args[0]
+    cron_expression = " ".join(args[1:6])
+    prompt = " ".join(args[6:])
+
+    # Auto-populate fields from context
+    chat_id = update.effective_chat.id
+    user_id = update.effective_user.id
+    settings = context.bot_data.get("settings")
+    working_dir = context.user_data.get(
+        "current_directory",
+        settings.approved_directory if settings else None,
+    )
+
+    try:
+        job_id = await scheduler.add_job(
+            job_name=job_name,
+            cron_expression=cron_expression,
+            prompt=prompt,
+            target_chat_ids=[chat_id],
+            working_directory=working_dir,
+            created_by=user_id,
+        )
+        await update.message.reply_html(
+            f"Job <b>{escape_html(job_name)}</b> created.\n"
+            f"ID: <code>{escape_html(job_id)}</code>\n"
+            f"Cron: <code>{escape_html(cron_expression)}</code>"
+        )
+    except Exception as e:
+        logger.exception("Failed to add scheduled job", error=str(e))
+        await update.message.reply_text(f"Failed to create job: {e}")
+
+
+async def _handle_remove(
+    update: Update, scheduler: JobScheduler, args: List[str]
+) -> None:
+    """Remove a scheduled job."""
+    if not args:
+        await update.message.reply_text("Usage: /schedule remove <job_id>")
+        return
+
+    job_id = args[0]
+    await scheduler.remove_job(job_id)
+    await update.message.reply_html(
+        f"Job <code>{escape_html(job_id)}</code> removed."
+    )
+
+
+async def _handle_pause(
+    update: Update, scheduler: JobScheduler, args: List[str]
+) -> None:
+    """Pause a scheduled job."""
+    if not args:
+        await update.message.reply_text("Usage: /schedule pause <job_id>")
+        return
+
+    job_id = args[0]
+    success = await scheduler.pause_job(job_id)
+    if success:
+        await update.message.reply_html(
+            f"Job <code>{escape_html(job_id)}</code> paused."
+        )
+    else:
+        await update.message.reply_text(f"Job '{job_id}' not found.")
+
+
+async def _handle_resume(
+    update: Update, scheduler: JobScheduler, args: List[str]
+) -> None:
+    """Resume a paused job."""
+    if not args:
+        await update.message.reply_text("Usage: /schedule resume <job_id>")
+        return
+
+    job_id = args[0]
+    success = await scheduler.resume_job(job_id)
+    if success:
+        await update.message.reply_html(
+            f"Job <code>{escape_html(job_id)}</code> resumed."
+        )
+    else:
+        await update.message.reply_text(f"Job '{job_id}' not found or failed to resume.")

--- a/src/bot/handlers/sdd_handler.py
+++ b/src/bot/handlers/sdd_handler.py
@@ -1,0 +1,231 @@
+"""Handler for the /sdd command — SDD pre-analysis workflow.
+
+Accepts a GitHub issue URL or a free-text description, builds a structured
+prompt, delegates to Claude Code via ClaudeIntegration, and relays the result
+back to the user as an HTML-formatted Telegram message.
+
+Claude performs all git operations and file writes inside the working directory
+(.agent/planning/sdd.md, .agent/context/files.md, .agent/context/approach.md).
+The handler is intentionally thin — it only constructs the prompt and routes
+the response.
+"""
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import structlog
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ...config.settings import Settings
+from ...security.audit import AuditLogger
+
+logger = structlog.get_logger()
+
+# Regex for detecting GitHub issue URLs
+_GITHUB_ISSUE_RE = re.compile(
+    r"https?://github\.com/[^/]+/[^/]+/issues/(\d+)", re.IGNORECASE
+)
+
+
+def _is_github_issue_url(text: str) -> bool:
+    """Return True when *text* looks like a GitHub issue URL."""
+    return bool(_GITHUB_ISSUE_RE.search(text.strip()))
+
+
+def _extract_issue_number(url: str) -> Optional[int]:
+    """Return the issue number embedded in a GitHub issue URL, or None."""
+    match = _GITHUB_ISSUE_RE.search(url.strip())
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _build_sdd_prompt(
+    arg: str,
+    working_dir: Path,
+    protected_branches: list[str],
+    is_url: bool,
+) -> str:
+    """Assemble the Claude prompt for an SDD pre-analysis run.
+
+    Args:
+        arg: The raw argument — either a GitHub issue URL or free-text.
+        working_dir: The repo directory Claude should work in.
+        protected_branches: List of branch names Claude must never push to.
+        is_url: Whether *arg* is a GitHub issue URL (True) or free text (False).
+
+    Returns:
+        A fully formed prompt string ready to pass to ClaudeIntegration.run_command().
+    """
+    protected_str = ", ".join(protected_branches) if protected_branches else "main, master, develop"
+
+    if is_url:
+        issue_block = (
+            f"GitHub issue URL: {arg}\n"
+            "Fetch the issue content by running: gh issue view <url>"
+        )
+    else:
+        issue_block = f"Issue / task description:\n{arg}"
+
+    prompt = f"""You are running a SDD pre-analysis on the repo at {working_dir}.
+
+Protected branches (NEVER push to these): {protected_str}
+
+{issue_block}
+
+Instructions:
+1. If a GitHub URL was provided, run: gh issue view {arg if is_url else '<url>'} to fetch the issue title and body.
+2. Infer branch type from the issue content:
+   - Bug report → Fix
+   - New feature → Feat
+   - Refactoring → Refactor
+   - Documentation → Docs
+   - Everything else → Chore
+3. Create a new branch following the naming convention:
+   - For numbered issues: {{Tipo}}/Issue{{N}}{{DescripcionEnPascalCase}}  (e.g. Feat/Issue5AddDarkMode)
+   - For free-text input: {{Tipo}}/{{DescripcionEnPascalCase}}            (e.g. Feat/AddDarkModeToSettingsPage)
+   Run: git checkout -b <branch-name>
+4. Explore the repo structure — focus on directories relevant to the issue.
+5. Write .agent/planning/sdd.md — what to implement, acceptance criteria.
+6. Write .agent/context/files.md — relevant files and their role.
+7. Write .agent/context/approach.md — suggested approach, alternatives, tradeoffs.
+8. Run: git add .agent/ && git commit -m "📝 docs(analysis): agregar pre-análisis {arg[:60] if not is_url else 'issue #' + str(_extract_issue_number(arg) or '?')}"
+9. Run: git push origin <branch-name>
+10. RESTRICTIONS:
+    - DO NOT modify any existing source file outside .agent/
+    - DO NOT open a Pull Request
+    - DO NOT run tests or builds
+    - DO NOT push to any protected branch ({protected_str})
+
+End with a brief summary containing:
+- Branch name created
+- Files written under .agent/
+- One-line problem statement
+"""
+    return prompt
+
+
+async def sdd_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the /sdd command — trigger an SDD pre-analysis workflow.
+
+    Usage: /sdd <github-issue-url | description>
+
+    The handler delegates the full analysis (branch creation, file writing,
+    git commit/push) to Claude Code via ClaudeIntegration. It only constructs
+    the prompt and relays the summary back to the user.
+    """
+    settings: Settings = context.bot_data["settings"]
+    audit_logger: AuditLogger = context.bot_data.get("audit_logger")
+    user_id = update.effective_user.id
+
+    logger.info("SDD command received", user_id=user_id)
+
+    # --- Feature flag check ---
+    if not settings.enable_sdd:
+        await update.message.reply_text("SDD command is disabled.")
+        if audit_logger:
+            await audit_logger.log_command(user_id, "sdd", [], False)
+        return
+
+    # --- Parse argument ---
+    text = update.message.text or ""
+    parts = text.split(maxsplit=1)
+    if len(parts) < 2 or not parts[1].strip():
+        await update.message.reply_text(
+            "Usage: <code>/sdd &lt;github-issue-url | description&gt;</code>\n\n"
+            "Examples:\n"
+            "  <code>/sdd https://github.com/owner/repo/issues/5</code>\n"
+            "  <code>/sdd Add dark mode to settings page</code>",
+            parse_mode="HTML",
+        )
+        if audit_logger:
+            await audit_logger.log_command(user_id, "sdd", [], False)
+        return
+
+    arg = parts[1].strip()
+    is_url = _is_github_issue_url(arg)
+
+    # --- Progress message ---
+    progress_msg = await update.message.reply_text("🔍 Analyzing...")
+
+    # --- Resolve working directory ---
+    current_dir = context.user_data.get(
+        "current_directory", settings.approved_directory
+    )
+
+    # --- Build prompt ---
+    prompt = _build_sdd_prompt(
+        arg=arg,
+        working_dir=Path(current_dir),
+        protected_branches=settings.sdd_protected_branches,
+        is_url=is_url,
+    )
+
+    # --- Delegate to Claude ---
+    claude_integration = context.bot_data.get("claude_integration")
+    if not claude_integration:
+        await progress_msg.edit_text(
+            "❌ Claude integration not available. Check configuration."
+        )
+        logger.error("SDD command: claude_integration not in bot_data", user_id=user_id)
+        return
+
+    session_id = context.user_data.get("claude_session_id")
+
+    try:
+        claude_response = await claude_integration.run_command(
+            prompt=prompt,
+            working_directory=current_dir,
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+        # Update session ID if a new session was created
+        if claude_response and claude_response.session_id:
+            context.user_data["claude_session_id"] = claude_response.session_id
+
+        response_text = (
+            claude_response.content
+            if claude_response and claude_response.content
+            else ""
+        )
+
+        if not response_text:
+            await progress_msg.edit_text(
+                "⚠️ SDD analysis completed but Claude returned an empty response."
+            )
+            logger.warning("SDD command: empty Claude response", user_id=user_id)
+            if audit_logger:
+                await audit_logger.log_command(user_id, "sdd", [arg], False)
+            return
+
+        # Telegram message limit is 4096 chars — truncate gracefully
+        MAX_LEN = 4000
+        if len(response_text) > MAX_LEN:
+            response_text = response_text[:MAX_LEN] + "\n\n… <i>(truncated)</i>"
+
+        await progress_msg.edit_text(
+            f"✅ <b>SDD Analysis Complete</b>\n\n{response_text}",
+            parse_mode="HTML",
+        )
+
+        if audit_logger:
+            await audit_logger.log_command(user_id, "sdd", [arg], True)
+
+        logger.info("SDD command completed successfully", user_id=user_id)
+
+    except Exception as exc:
+        error_msg = str(exc)
+        logger.error(
+            "SDD command failed",
+            user_id=user_id,
+            error=error_msg,
+        )
+        await progress_msg.edit_text(
+            f"❌ <b>SDD analysis failed</b>\n\n<code>{error_msg[:500]}</code>",
+            parse_mode="HTML",
+        )
+        if audit_logger:
+            await audit_logger.log_command(user_id, "sdd", [arg], False)

--- a/src/bot/handlers/topics_handler.py
+++ b/src/bot/handlers/topics_handler.py
@@ -1,0 +1,241 @@
+"""Handler for /topics command — add | list | delete subcommands.
+
+Manages the dynamic project-thread registry. Projects registered here
+are persisted in the `projects` table and served via
+`load_project_registry_from_db` at startup (DB-only mode).
+
+Usage:
+  /topics add <slug> <name> <path> [git_url]
+  /topics list
+  /topics delete <slug>
+"""
+
+from pathlib import Path
+from typing import List, Optional
+
+import structlog
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ...bot.features.git_integration import GitError, GitIntegration
+from ...config.settings import Settings
+from ...projects import load_project_registry_from_db
+from ...storage.repositories import ProjectRepository
+
+logger = structlog.get_logger()
+
+_USAGE = (
+    "Usage: /topics &lt;add|list|delete&gt; [args]\n"
+    "/topics add &lt;slug&gt; &lt;name&gt; &lt;path&gt; [git_url]\n"
+    "/topics list\n"
+    "/topics delete &lt;slug&gt;"
+)
+
+
+async def topics_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Entry point for /topics subcommands: add, list, delete."""
+    args: List[str] = context.args or []
+
+    if not args:
+        await update.effective_message.reply_text(_USAGE, parse_mode="HTML")
+        return
+
+    subcommand = args[0].lower()
+    rest = args[1:]
+
+    if subcommand == "add":
+        await _topics_add(update, context, rest)
+    elif subcommand == "list":
+        await _topics_list(update, context)
+    elif subcommand == "delete":
+        await _topics_delete(update, context, rest)
+    else:
+        await update.effective_message.reply_text(
+            f"❓ Unknown subcommand: <code>{subcommand}</code>\n\n{_USAGE}",
+            parse_mode="HTML",
+        )
+
+
+async def _topics_add(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, args: List[str]
+) -> None:
+    """Handle /topics add <slug> <name> <path> [git_url]."""
+    if len(args) < 3:
+        await update.effective_message.reply_text(
+            f"❌ <b>Missing arguments.</b>\n\n{_USAGE}", parse_mode="HTML"
+        )
+        return
+
+    slug = args[0]
+    name = args[1]
+    path_str = args[2]
+    git_url: Optional[str] = args[3] if len(args) > 3 else None
+
+    # Must be sent from inside a forum topic
+    thread_id: Optional[int] = update.effective_message.message_thread_id
+    if thread_id is None:
+        await update.effective_message.reply_text(
+            "❌ <b>Must be sent from inside a forum topic.</b>\n"
+            "Run <code>/topics add</code> from the topic you want to register.",
+            parse_mode="HTML",
+        )
+        return
+
+    chat_id = update.effective_chat.id
+    settings: Settings = context.bot_data["settings"]
+    approved_dir = settings.approved_directory.resolve()
+
+    # Resolve absolute path — treat path_str as either absolute or relative to approved_dir
+    raw_path = Path(path_str)
+    abs_path = (raw_path if raw_path.is_absolute() else approved_dir / raw_path).resolve()
+
+    try:
+        abs_path.relative_to(approved_dir)
+    except ValueError:
+        await update.effective_message.reply_text(
+            f"❌ <b>Invalid path.</b>\n"
+            f"<code>{path_str}</code> is outside the approved directory.",
+            parse_mode="HTML",
+        )
+        return
+
+    # If no git_url, path must already exist as a directory
+    if git_url is None:
+        if not abs_path.exists() or not abs_path.is_dir():
+            await update.effective_message.reply_text(
+                f"❌ <b>Path does not exist or is not a directory.</b>\n"
+                f"<code>{abs_path}</code>\n\n"
+                "Provide a <code>git_url</code> to clone the repository first.",
+                parse_mode="HTML",
+            )
+            return
+    else:
+        # Clone the repository into abs_path
+        git: Optional[GitIntegration] = context.bot_data.get("git_integration")
+        if git is None:
+            await update.effective_message.reply_text(
+                "❌ <b>Git integration is not available.</b>",
+                parse_mode="HTML",
+            )
+            return
+        try:
+            await git.clone_repo(git_url, abs_path)
+        except GitError as exc:
+            await update.effective_message.reply_text(
+                f"❌ <b>Git clone failed.</b>\n<pre>{exc}</pre>\n"
+                "No project was registered.",
+                parse_mode="HTML",
+            )
+            return
+
+    # Persist project record
+    project_repo: ProjectRepository = context.bot_data["storage"].projects
+    await project_repo.upsert(
+        project_slug=slug,
+        chat_id=chat_id,
+        name=name,
+        absolute_path=str(abs_path),
+        git_url=git_url,
+    )
+
+    # Persist thread mapping
+    thread_repo = context.bot_data["storage"].project_threads
+    await thread_repo.upsert_mapping(
+        project_slug=slug,
+        chat_id=chat_id,
+        message_thread_id=thread_id,
+        topic_name=name,
+    )
+
+    # Reload in-memory registry
+    manager = context.bot_data.get("project_threads_manager")
+    if manager is not None:
+        registry = await load_project_registry_from_db(
+            repo=project_repo,
+            approved_directory=settings.approved_directory,
+            chat_id=chat_id,
+        )
+        manager.registry = registry
+        logger.info("Registry reloaded after /topics add", slug=slug, chat_id=chat_id)
+
+    await update.effective_message.reply_text(
+        f"✅ <b>Project registered.</b>\n"
+        f"<b>Slug:</b> <code>{slug}</code>\n"
+        f"<b>Name:</b> {name}\n"
+        f"<b>Path:</b> <code>{abs_path}</code>",
+        parse_mode="HTML",
+    )
+
+
+async def _topics_list(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Handle /topics list — show all registered projects for this chat."""
+    chat_id = update.effective_chat.id
+    project_repo: ProjectRepository = context.bot_data["storage"].projects
+    rows = await project_repo.list_by_chat(chat_id=chat_id, enabled_only=False)
+
+    if not rows:
+        await update.effective_message.reply_text(
+            "ℹ️ No projects registered. Use /topics add to register one.",
+            parse_mode="HTML",
+        )
+        return
+
+    lines = []
+    for row in rows:
+        status = "enabled" if row.enabled else "disabled"
+        lines.append(
+            f"• <code>{row.project_slug}</code> — {row.name}\n"
+            f"  Path: <code>{row.absolute_path}</code> [{status}]"
+        )
+
+    text = "\n\n".join(lines)
+    await update.effective_message.reply_text(text, parse_mode="HTML")
+
+
+async def _topics_delete(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, args: List[str]
+) -> None:
+    """Handle /topics delete <slug>."""
+    if not args:
+        await update.effective_message.reply_text(
+            f"❌ <b>Missing slug.</b>\n\n{_USAGE}", parse_mode="HTML"
+        )
+        return
+
+    slug = args[0]
+    chat_id = update.effective_chat.id
+    settings: Settings = context.bot_data["settings"]
+    project_repo: ProjectRepository = context.bot_data["storage"].projects
+
+    rowcount = await project_repo.delete(project_slug=slug, chat_id=chat_id)
+    if rowcount == 0:
+        await update.effective_message.reply_text(
+            f"❌ <b>Project not found:</b> <code>{slug}</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    # Deactivate the thread mapping
+    await context.bot_data["storage"].project_threads.set_active(
+        chat_id=chat_id, project_slug=slug, is_active=False
+    )
+
+    # Reload in-memory registry
+    manager = context.bot_data.get("project_threads_manager")
+    if manager is not None:
+        registry = await load_project_registry_from_db(
+            repo=project_repo,
+            approved_directory=settings.approved_directory,
+            chat_id=chat_id,
+        )
+        manager.registry = registry
+        logger.info(
+            "Registry reloaded after /topics delete", slug=slug, chat_id=chat_id
+        )
+
+    await update.effective_message.reply_text(
+        f"✅ Project <code>{slug}</code> removed.",
+        parse_mode="HTML",
+    )

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -146,7 +146,7 @@ class MessageOrchestrator:
             context.bot_data["settings"] = self.settings
             context.user_data.pop("_thread_context", None)
 
-            is_sync_bypass = handler.__name__ == "sync_threads"
+            is_sync_bypass = handler.__name__ in {"sync_threads", "topics_command"}
             is_start_bypass = handler.__name__ in {"start_command", "agentic_start"}
             message_thread_id = self._extract_message_thread_id(update)
             should_enforce = self.settings.enable_project_threads
@@ -336,6 +336,9 @@ class MessageOrchestrator:
             handlers.append(("voice", self.agentic_voice_command))
         if self.settings.enable_project_threads:
             handlers.append(("sync_threads", command.sync_threads))
+            from .handlers.topics_handler import topics_command
+
+            handlers.append(("topics", topics_command))
         if self.settings.enable_scheduler:
             from .handlers import schedule
 
@@ -446,6 +449,9 @@ class MessageOrchestrator:
         ]
         if self.settings.enable_project_threads:
             handlers.append(("sync_threads", command.sync_threads))
+            from .handlers.topics_handler import topics_command
+
+            handlers.append(("topics", topics_command))
         if self.settings.enable_scheduler:
             from .handlers import schedule
 
@@ -500,6 +506,11 @@ class MessageOrchestrator:
                 )
             if self.settings.enable_project_threads:
                 commands.append(BotCommand("sync_threads", "Sync project topics"))
+                commands.append(
+                    BotCommand(
+                        "topics", "Registrar y gestionar proyectos vinculados a topics"
+                    )
+                )
             if self.settings.enable_scheduler:
                 commands.append(BotCommand("schedule", "Manage scheduled jobs"))
             return commands
@@ -523,6 +534,11 @@ class MessageOrchestrator:
             ]
             if self.settings.enable_project_threads:
                 commands.append(BotCommand("sync_threads", "Sync project topics"))
+                commands.append(
+                    BotCommand(
+                        "topics", "Registrar y gestionar proyectos vinculados a topics"
+                    )
+                )
             if self.settings.enable_scheduler:
                 commands.append(BotCommand("schedule", "Manage scheduled jobs"))
             return commands

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -318,7 +318,7 @@ class MessageOrchestrator:
 
     def _register_agentic_handlers(self, app: Application) -> None:
         """Register agentic handlers: commands + text/file/photo."""
-        from .handlers import command
+        from .handlers import command, sdd_handler
 
         # Commands
         handlers = [
@@ -328,7 +328,10 @@ class MessageOrchestrator:
             ("verbose", self.agentic_verbose),
             ("repo", self.agentic_repo),
             ("restart", command.restart_command),
+            ("sdd", sdd_handler.sdd_command),
         ]
+        if self.settings.enable_voice_replies:
+            handlers.append(("voice", self.agentic_voice_command))
         if self.settings.enable_project_threads:
             handlers.append(("sync_threads", command.sync_threads))
 
@@ -461,7 +464,12 @@ class MessageOrchestrator:
                 BotCommand("verbose", "Set output verbosity (0/1/2)"),
                 BotCommand("repo", "List repos / switch workspace"),
                 BotCommand("restart", "Restart the bot"),
+                BotCommand("sdd", "Analyze issue & create .agent/ branch"),
             ]
+            if self.settings.enable_voice_replies:
+                commands.append(
+                    BotCommand("voice", "Toggle voice replies (on/off/auto)")
+                )
             if self.settings.enable_project_threads:
                 commands.append(BotCommand("sync_threads", "Sync project topics"))
             return commands
@@ -549,6 +557,8 @@ class MessageOrchestrator:
         context.user_data["claude_session_id"] = None
         context.user_data["session_started"] = True
         context.user_data["force_new_session"] = True
+        # Clear voice reply preference on new session (spec requirement)
+        context.user_data.pop("voice_reply", None)
 
         await update.message.reply_text("Session reset. What's next?")
 
@@ -579,6 +589,112 @@ class MessageOrchestrator:
         await update.message.reply_text(
             f"📂 {dir_display} · Session: {session_status}{cost_str}"
         )
+
+    async def agentic_voice_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Handle /voice on|off|auto — toggle outgoing voice note replies.
+
+        Usage:
+            /voice       — show current status
+            /voice on    — always reply with voice notes
+            /voice off   — always reply with text (default)
+            /voice auto  — reply with voice when reply is short enough
+        """
+        if not self.settings.enable_voice_replies:
+            await update.message.reply_text(
+                "Voice replies are disabled. "
+                "Set ENABLE_VOICE_REPLIES=true to enable this feature."
+            )
+            return
+
+        args = update.message.text.split()[1:] if update.message.text else []
+
+        if not args:
+            # Show current status
+            current = context.user_data.get("voice_reply", "off")
+            await update.message.reply_text(
+                f"Voice replies: <b>{current}</b>\n\n"
+                "Usage: <code>/voice on|off|auto</code>\n"
+                "  on   = always send voice notes\n"
+                "  off  = always send text (default)\n"
+                f"  auto = voice when reply ≤ {self.settings.voice_reply_max_words} words",
+                parse_mode="HTML",
+            )
+            return
+
+        arg = args[0].lower().strip()
+        if arg not in {"on", "off", "auto"}:
+            await update.message.reply_text(
+                "Invalid argument. Usage: <code>/voice on|off|auto</code>",
+                parse_mode="HTML",
+            )
+            return
+
+        context.user_data["voice_reply"] = arg
+        labels = {
+            "on": "Voice replies enabled — I'll reply with voice notes.",
+            "off": "Voice replies disabled — I'll reply with text.",
+            "auto": (
+                f"Auto voice mode — voice for replies up to "
+                f"{self.settings.voice_reply_max_words} words."
+            ),
+        }
+        await update.message.reply_text(labels[arg])
+
+    # Keywords that signal the user explicitly wants a voice reply.
+    _VOICE_REQUEST_KEYWORDS: frozenset = frozenset(
+        [
+            # Spanish
+            "en voz",
+            "respondé en audio",
+            "responde en audio",
+            "nota de voz",
+            "mandame un audio",
+            "mándame un audio",
+            "mandame audio",
+            "audio",
+            "voz",
+            "escúchame",
+            "escuchame",
+            # English
+            "voice note",
+            "respond with audio",
+            "send audio",
+            "voice",
+        ]
+    )
+
+    def _user_wants_voice(self, user_message: str) -> bool:
+        """Return True if the user's message contains an explicit voice request."""
+        normalized = user_message.lower()
+        return any(kw in normalized for kw in self._VOICE_REQUEST_KEYWORDS)
+
+    def _should_send_voice(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        response_text: str,
+        user_message: str = "",
+    ) -> bool:
+        """Return True if the reply should be sent as a voice note.
+
+        Logic:
+        - voice_reply == "off"  → always False (default)
+        - voice_reply == "on"   → True only when the user's message explicitly
+                                   requests a voice reply (keyword detection)
+        - voice_reply == "auto" → True when word count of *response* ≤
+                                   voice_reply_max_words, ignoring user intent
+        """
+        if not self.settings.enable_voice_replies:
+            return False
+
+        mode = context.user_data.get("voice_reply", "off")
+        if mode == "on":
+            return self._user_wants_voice(user_message)
+        if mode == "auto":
+            word_count = len(response_text.split())
+            return word_count <= self.settings.voice_reply_max_words
+        return False
 
     def _get_verbose_level(self, context: ContextTypes.DEFAULT_TYPE) -> int:
         """Return effective verbose level: per-user override or global default."""
@@ -1082,9 +1198,35 @@ class MessageOrchestrator:
         # Use MCP-collected images (from send_image_to_user tool calls)
         images: List[ImageAttachment] = mcp_images
 
+        # --- Voice reply path ---
+        # Attempt to send as voice note when user has enabled /voice on|auto.
+        # Only applies when there is a single text message and no image attachments.
+        full_text = (
+            formatted_messages[0].text
+            if len(formatted_messages) == 1 and formatted_messages[0].text
+            else None
+        )
+        voice_sent = False
+        if full_text and not images and self._should_send_voice(
+            context, full_text, user_message=message_text
+        ):
+            features = context.bot_data.get("features")
+            voice_sender = features.get_voice_sender() if features else None
+            if voice_sender:
+                voice_sent = await voice_sender.send_voice_reply(
+                    text=full_text,
+                    update=update,
+                    reply_to_message_id=update.message.message_id,
+                )
+                if not voice_sent:
+                    logger.warning(
+                        "Voice send failed, falling back to text reply",
+                        word_count=len(full_text.split()),
+                    )
+
         # Try to combine text + images in one message when possible
         caption_sent = False
-        if images and len(formatted_messages) == 1:
+        if not voice_sent and images and len(formatted_messages) == 1:
             msg = formatted_messages[0]
             if msg.text and len(msg.text) <= 1024:
                 try:
@@ -1098,8 +1240,8 @@ class MessageOrchestrator:
                 except Exception as img_err:
                     logger.warning("Image+caption send failed", error=str(img_err))
 
-        # Send text messages (skip if caption was already embedded in photos)
-        if not caption_sent:
+        # Send text messages (skip if caption was already embedded in photos or voice was sent)
+        if not voice_sent and not caption_sent:
             for i, message in enumerate(formatted_messages):
                 if not message.text or not message.text.strip():
                     continue
@@ -1501,6 +1643,36 @@ class MessageOrchestrator:
 
         # Use MCP-collected images (from send_image_to_user tool calls).
         images: List[ImageAttachment] = mcp_images_media
+
+        # --- Voice reply path ---
+        # Attempt to send as voice note when user has enabled /voice on|auto.
+        # Only applies when there is a single text message and no image attachments.
+        full_text = (
+            formatted_messages[0].text
+            if len(formatted_messages) == 1 and formatted_messages[0].text
+            else None
+        )
+        voice_sent = False
+        if full_text and not images and self._should_send_voice(
+            context, full_text, user_message=prompt
+        ):
+            features = context.bot_data.get("features")
+            voice_sender = features.get_voice_sender() if features else None
+            if voice_sender:
+                voice_sent = await voice_sender.send_voice_reply(
+                    text=full_text,
+                    update=update,
+                    reply_to_message_id=update.message.message_id,
+                )
+                if not voice_sent:
+                    logger.warning(
+                        "Voice send failed, falling back to text reply",
+                        word_count=len(full_text.split()),
+                    )
+
+        if voice_sent:
+            # Voice note sent successfully — no text reply needed.
+            return
 
         caption_sent = False
         if images and len(formatted_messages) == 1:

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -7,6 +7,7 @@ classic mode, delegates to existing full-featured handlers.
 
 import asyncio
 import re
+import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -412,6 +413,14 @@ class MessageOrchestrator:
             )
         )
 
+        # Voice set callbacks (voice selection + pagination)
+        app.add_handler(
+            CallbackQueryHandler(
+                self._inject_deps(self._handle_voice_set_callback),
+                pattern=r"^voice_",
+            )
+        )
+
         logger.info("Agentic handlers registered")
 
     def _register_classic_handlers(self, app: Application) -> None:
@@ -614,16 +623,140 @@ class MessageOrchestrator:
             f"📂 {dir_display} · Session: {session_status}{cost_str}"
         )
 
+    # --- Voice set helpers ---
+
+    _VOICE_COUNTRY_FLAGS: dict = {
+        "AR": "🇦🇷", "ES": "🇪🇸", "MX": "🇲🇽", "CO": "🇨🇴",
+        "US": "🇺🇸", "CL": "🇨🇱", "PE": "🇵🇪", "VE": "🇻🇪",
+        "UY": "🇺🇾", "BO": "🇧🇴", "EC": "🇪🇨", "PY": "🇵🇾",
+        "CR": "🇨🇷", "GT": "🇬🇹", "HN": "🇭🇳", "NI": "🇳🇮",
+        "PA": "🇵🇦", "DO": "🇩🇴", "CU": "🇨🇺", "PR": "🇵🇷",
+        "GB": "🇬🇧", "AU": "🇦🇺", "CA": "🇨🇦", "IN": "🇮🇳",
+        "IE": "🇮🇪", "NZ": "🇳🇿", "PH": "🇵🇭", "SG": "🇸🇬",
+        "ZA": "🇿🇦", "DE": "🇩🇪", "FR": "🇫🇷", "IT": "🇮🇹",
+        "BR": "🇧🇷", "PT": "🇵🇹",
+    }
+
+    _VOICES_PER_PAGE: int = 12
+
+    @staticmethod
+    def _voice_display(voice_name: str, gender: str) -> str:
+        """Format 'es-AR-TomasNeural' + 'Male' as '🇦🇷 Tomas ♂'."""
+        parts = voice_name.split("-")
+        country = parts[1] if len(parts) >= 2 else ""
+        raw_name = parts[2].replace("Neural", "") if len(parts) >= 3 else voice_name
+        flag = MessageOrchestrator._VOICE_COUNTRY_FLAGS.get(country, f"[{country}]")
+        gender_icon = "♂" if gender.lower() == "male" else "♀"
+        return f"{flag} {raw_name} {gender_icon}"
+
+    @staticmethod
+    async def _fetch_edge_tts_voices(
+        lang_prefix: str = "es",
+    ) -> list:
+        """Fetch available voices via the edge_tts Python API, filtered by lang_prefix."""
+        try:
+            import edge_tts
+
+            manager = await edge_tts.VoicesManager.create()
+            return [
+                (v["ShortName"], v["Gender"])
+                for v in manager.voices
+                if v["ShortName"].startswith(f"{lang_prefix}-")
+            ]
+        except Exception:
+            return []
+
+    @staticmethod
+    def _voice_set_keyboard(
+        voices: list, page: int, lang_prefix: str
+    ) -> "InlineKeyboardMarkup":
+        """Build a 2-column paginated voice selection keyboard."""
+        vpp = MessageOrchestrator._VOICES_PER_PAGE
+        total = len(voices)
+        total_pages = max(1, (total + vpp - 1) // vpp)
+        page = max(0, min(page, total_pages - 1))
+
+        page_voices = voices[page * vpp: page * vpp + vpp]
+
+        rows = []
+        for i in range(0, len(page_voices), 2):
+            row = []
+            for name, gender in page_voices[i: i + 2]:
+                label = MessageOrchestrator._voice_display(name, gender)
+                row.append(
+                    InlineKeyboardButton(label, callback_data=f"voice_select:{name}")
+                )
+            rows.append(row)
+
+        nav: list = []
+        if page > 0:
+            nav.append(
+                InlineKeyboardButton(
+                    "← Prev", callback_data=f"voice_page:{lang_prefix}:{page - 1}"
+                )
+            )
+        nav.append(
+            InlineKeyboardButton(
+                f"{page + 1}/{total_pages}",
+                callback_data=f"voice_noop",
+            )
+        )
+        if page < total_pages - 1:
+            nav.append(
+                InlineKeyboardButton(
+                    "Next →", callback_data=f"voice_page:{lang_prefix}:{page + 1}"
+                )
+            )
+        if nav:
+            rows.append(nav)
+
+        return InlineKeyboardMarkup(rows)
+
+    async def _handle_voice_set_callback(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Handle voice_select:, voice_page:, and voice_noop callbacks."""
+        query = update.callback_query
+        await query.answer()
+
+        data = query.data or ""
+
+        if data == "voice_noop":
+            return
+
+        if data.startswith("voice_select:"):
+            voice_name = data.split(":", 1)[1]
+            context.user_data["tts_voice_override"] = voice_name
+            display = self._voice_display(voice_name, "")
+            await query.edit_message_text(
+                f"Voice set to <b>{display}</b> (<code>{voice_name}</code>)",
+                parse_mode="HTML",
+            )
+            return
+
+        if data.startswith("voice_page:"):
+            _, lang, page_str = data.split(":", 2)
+            page = int(page_str)
+            voices = await self._fetch_edge_tts_voices(lang)
+            if not voices:
+                await query.edit_message_text("Could not load voice list. Is edge-tts installed?")
+                return
+            kb = self._voice_set_keyboard(voices, page, lang)
+            await query.edit_message_reply_markup(reply_markup=kb)
+
+    # --- /voice command ---
+
     async def agentic_voice_command(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
     ) -> None:
-        """Handle /voice on|off|auto — toggle outgoing voice note replies.
+        """Handle /voice on|off|auto|set — toggle outgoing voice note replies.
 
         Usage:
             /voice       — show current status
             /voice on    — always reply with voice notes
             /voice off   — always reply with text (default)
-            /voice auto  — reply with voice when reply is short enough
+            /voice auto  — voice when you explicitly ask for it
+            /voice set   — pick a voice from edge-tts (interactive menu)
         """
         if not self.settings.enable_voice_replies:
             await update.message.reply_text(
@@ -637,20 +770,43 @@ class MessageOrchestrator:
         if not args:
             # Show current status
             current = context.user_data.get("voice_reply", "off")
+            current_voice = context.user_data.get(
+                "tts_voice_override", self.settings.edge_tts_voice
+            )
             await update.message.reply_text(
-                f"Voice replies: <b>{current}</b>\n\n"
-                "Usage: <code>/voice on|off|auto</code>\n"
+                f"Voice replies: <b>{current}</b>  ·  Voice: <code>{current_voice}</code>\n\n"
+                "Usage: <code>/voice on|off|auto|set</code>\n"
                 "  on   = always send voice notes\n"
                 "  off  = always send text (default)\n"
-                f"  auto = voice when reply ≤ {self.settings.voice_reply_max_words} words",
+                "  auto = voice when you ask for it (keyword detection)\n"
+                "  set  = pick a voice from the available list",
                 parse_mode="HTML",
             )
             return
 
         arg = args[0].lower().strip()
+
+        if arg == "set":
+            lang = args[1].lower() if len(args) > 1 else "es"
+            await update.message.reply_text("Loading voices…")
+            voices = await self._fetch_edge_tts_voices(lang)
+            if not voices:
+                await update.message.reply_text(
+                    "Could not load voice list. Is <code>edge-tts</code> installed?",
+                    parse_mode="HTML",
+                )
+                return
+            kb = self._voice_set_keyboard(voices, 0, lang)
+            await update.message.reply_text(
+                f"Available <b>{lang.upper()}</b> voices — tap to select:",
+                reply_markup=kb,
+                parse_mode="HTML",
+            )
+            return
+
         if arg not in {"on", "off", "auto"}:
             await update.message.reply_text(
-                "Invalid argument. Usage: <code>/voice on|off|auto</code>",
+                "Invalid argument. Usage: <code>/voice on|off|auto|set</code>",
                 parse_mode="HTML",
             )
             return
@@ -659,10 +815,7 @@ class MessageOrchestrator:
         labels = {
             "on": "Voice replies enabled — I'll reply with voice notes.",
             "off": "Voice replies disabled — I'll reply with text.",
-            "auto": (
-                f"Auto voice mode — voice for replies up to "
-                f"{self.settings.voice_reply_max_words} words."
-            ),
+            "auto": "Auto voice mode — sends voice when you ask for it (e.g. 'nota de voz').",
         }
         await update.message.reply_text(labels[arg])
 
@@ -714,11 +867,10 @@ class MessageOrchestrator:
 
         mode = context.user_data.get("voice_reply", "off")
         if mode == "on":
-            return self._user_wants_voice(user_message)
-        if mode == "auto":
-            word_count = len(response_text.split())
-            return word_count <= self.settings.voice_reply_max_words
-        return False
+            return True  # always voice — user explicitly enabled it
+        # "auto" and "off": honor explicit one-shot voice requests regardless of mode.
+        # "off" means "don't send voice proactively", not "ignore explicit voice requests".
+        return self._user_wants_voice(user_message)
 
     def _get_verbose_level(self, context: ContextTypes.DEFAULT_TYPE) -> int:
         """Return effective verbose level: per-user override or global default."""
@@ -1078,6 +1230,12 @@ class MessageOrchestrator:
 
         verbose_level = self._get_verbose_level(context)
 
+        # Suppress streaming output when voice mode is active — the user will receive
+        # a voice note, so showing intermediate text is noise. Force quiet mode.
+        voice_mode = context.user_data.get("voice_reply", "off")
+        if voice_mode in ("on", "auto") and self.settings.enable_voice_replies:
+            verbose_level = 0
+
         # Create Stop button and interrupt event
         interrupt_event = asyncio.Event()
         stop_kb = InlineKeyboardMarkup(
@@ -1226,12 +1384,20 @@ class MessageOrchestrator:
 
         # --- Voice reply path ---
         # Attempt to send as voice note when user has enabled /voice on|auto.
-        # Only applies when there is a single text message and no image attachments.
-        full_text = (
-            formatted_messages[0].text
-            if len(formatted_messages) == 1 and formatted_messages[0].text
-            else None
-        )
+        # When voice mode is active, join all message parts into one text so that
+        # multi-part Claude responses are still delivered as a single voice note.
+        if not images and self._should_send_voice(
+            context, "", user_message=message_text
+        ):
+            full_text = "\n\n".join(
+                m.text for m in formatted_messages if m.text and m.text.strip()
+            ) or None
+        else:
+            full_text = (
+                formatted_messages[0].text
+                if len(formatted_messages) == 1 and formatted_messages[0].text
+                else None
+            )
         voice_sent = False
         if full_text and not images and self._should_send_voice(
             context, full_text, user_message=message_text
@@ -1243,6 +1409,7 @@ class MessageOrchestrator:
                     text=full_text,
                     update=update,
                     reply_to_message_id=update.message.message_id,
+                    voice_override=context.user_data.get("tts_voice_override"),
                 )
                 if not voice_sent:
                     logger.warning(
@@ -1623,6 +1790,9 @@ class MessageOrchestrator:
         force_new = bool(context.user_data.get("force_new_session"))
 
         verbose_level = self._get_verbose_level(context)
+        voice_mode = context.user_data.get("voice_reply", "off")
+        if voice_mode in ("on", "auto") and self.settings.enable_voice_replies:
+            verbose_level = 0
         tool_log: List[Dict[str, Any]] = []
         mcp_images_media: List[ImageAttachment] = []
         on_stream = self._make_stream_callback(
@@ -1676,12 +1846,20 @@ class MessageOrchestrator:
 
         # --- Voice reply path ---
         # Attempt to send as voice note when user has enabled /voice on|auto.
-        # Only applies when there is a single text message and no image attachments.
-        full_text = (
-            formatted_messages[0].text
-            if len(formatted_messages) == 1 and formatted_messages[0].text
-            else None
-        )
+        # When voice mode is active, join all message parts into one text so that
+        # multi-part Claude responses are still delivered as a single voice note.
+        if not images and self._should_send_voice(
+            context, "", user_message=prompt
+        ):
+            full_text = "\n\n".join(
+                m.text for m in formatted_messages if m.text and m.text.strip()
+            ) or None
+        else:
+            full_text = (
+                formatted_messages[0].text
+                if len(formatted_messages) == 1 and formatted_messages[0].text
+                else None
+            )
         voice_sent = False
         if full_text and not images and self._should_send_voice(
             context, full_text, user_message=prompt
@@ -1693,6 +1871,7 @@ class MessageOrchestrator:
                     text=full_text,
                     update=update,
                     reply_to_message_id=update.message.message_id,
+                    voice_override=context.user_data.get("tts_voice_override"),
                 )
                 if not voice_sent:
                     logger.warning(

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -331,6 +331,10 @@ class MessageOrchestrator:
         ]
         if self.settings.enable_project_threads:
             handlers.append(("sync_threads", command.sync_threads))
+        if self.settings.enable_scheduler:
+            from .handlers import schedule
+
+            handlers.append(("schedule", schedule.schedule_command))
 
         # Derive known commands dynamically — avoids drift when new commands are added
         self._known_commands: frozenset[str] = frozenset(cmd for cmd, _ in handlers)
@@ -420,6 +424,10 @@ class MessageOrchestrator:
         ]
         if self.settings.enable_project_threads:
             handlers.append(("sync_threads", command.sync_threads))
+        if self.settings.enable_scheduler:
+            from .handlers import schedule
+
+            handlers.append(("schedule", schedule.schedule_command))
 
         for cmd, handler in handlers:
             app.add_handler(CommandHandler(cmd, self._inject_deps(handler)))
@@ -464,6 +472,8 @@ class MessageOrchestrator:
             ]
             if self.settings.enable_project_threads:
                 commands.append(BotCommand("sync_threads", "Sync project topics"))
+            if self.settings.enable_scheduler:
+                commands.append(BotCommand("schedule", "Manage scheduled jobs"))
             return commands
         else:
             commands = [
@@ -484,6 +494,8 @@ class MessageOrchestrator:
             ]
             if self.settings.enable_project_threads:
                 commands.append(BotCommand("sync_threads", "Sync project topics"))
+            if self.settings.enable_scheduler:
+                commands.append(BotCommand("schedule", "Manage scheduled jobs"))
             return commands
 
     # --- Agentic handlers ---

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -327,6 +327,7 @@ class MessageOrchestrator:
             ("status", self.agentic_status),
             ("verbose", self.agentic_verbose),
             ("repo", self.agentic_repo),
+            ("model", command.model_command),
             ("restart", command.restart_command),
         ]
         if self.settings.enable_project_threads:
@@ -392,6 +393,14 @@ class MessageOrchestrator:
             )
         )
 
+        # Model/effort selection callbacks
+        app.add_handler(
+            CallbackQueryHandler(
+                self._inject_deps(command.model_callback),
+                pattern=r"^(model|effort):",
+            )
+        )
+
         # Only cd: callbacks (for project selection), scoped by pattern
         app.add_handler(
             CallbackQueryHandler(
@@ -420,6 +429,7 @@ class MessageOrchestrator:
             ("export", command.export_session),
             ("actions", command.quick_actions),
             ("git", command.git_command),
+            ("model", command.model_command),
             ("restart", command.restart_command),
         ]
         if self.settings.enable_project_threads:
@@ -468,6 +478,7 @@ class MessageOrchestrator:
                 BotCommand("status", "Show session status"),
                 BotCommand("verbose", "Set output verbosity (0/1/2)"),
                 BotCommand("repo", "List repos / switch workspace"),
+                BotCommand("model", "Switch Claude model and effort"),
                 BotCommand("restart", "Restart the bot"),
             ]
             if self.settings.enable_project_threads:
@@ -490,6 +501,7 @@ class MessageOrchestrator:
                 BotCommand("export", "Export current session"),
                 BotCommand("actions", "Show quick actions"),
                 BotCommand("git", "Git repository commands"),
+                BotCommand("model", "Switch Claude model and effort"),
                 BotCommand("restart", "Restart the bot"),
             ]
             if self.settings.enable_project_threads:
@@ -1026,6 +1038,8 @@ class MessageOrchestrator:
                 on_stream=on_stream,
                 force_new=force_new,
                 interrupt_event=interrupt_event,
+                model_override=context.user_data.get("model_override"),
+                effort_override=context.user_data.get("effort_override"),
             )
 
             # New session created successfully — clear the one-shot flag
@@ -1276,6 +1290,8 @@ class MessageOrchestrator:
                 session_id=session_id,
                 on_stream=on_stream,
                 force_new=force_new,
+                model_override=context.user_data.get("model_override"),
+                effort_override=context.user_data.get("effort_override"),
             )
 
             if force_new:
@@ -1486,6 +1502,8 @@ class MessageOrchestrator:
                 on_stream=on_stream,
                 force_new=force_new,
                 images=images,
+                model_override=context.user_data.get("model_override"),
+                effort_override=context.user_data.get("effort_override"),
             )
         finally:
             heartbeat.cancel()

--- a/src/claude/facade.py
+++ b/src/claude/facade.py
@@ -40,6 +40,8 @@ class ClaudeIntegration:
         force_new: bool = False,
         interrupt_event: Optional["asyncio.Event"] = None,
         images: Optional[List[Dict[str, str]]] = None,
+        model_override: Optional[str] = None,
+        effort_override: Optional[str] = None,
     ) -> ClaudeResponse:
         """Run Claude Code command with full integration."""
         logger.info(
@@ -49,6 +51,8 @@ class ClaudeIntegration:
             session_id=session_id,
             prompt_length=len(prompt),
             force_new=force_new,
+            model_override=model_override,
+            effort_override=effort_override,
         )
 
         # If no session_id provided, try to find an existing session for this
@@ -90,6 +94,8 @@ class ClaudeIntegration:
                     stream_callback=on_stream,
                     interrupt_event=interrupt_event,
                     images=images,
+                    model_override=model_override,
+                    effort_override=effort_override,
                 )
             except Exception as resume_error:
                 # If resume failed (e.g., session expired/missing on Claude's side),
@@ -116,6 +122,8 @@ class ClaudeIntegration:
                         stream_callback=on_stream,
                         interrupt_event=interrupt_event,
                         images=images,
+                        model_override=model_override,
+                        effort_override=effort_override,
                     )
                 else:
                     raise
@@ -161,6 +169,8 @@ class ClaudeIntegration:
         stream_callback: Optional[Callable] = None,
         interrupt_event: Optional[asyncio.Event] = None,
         images: Optional[List[Dict[str, str]]] = None,
+        model_override: Optional[str] = None,
+        effort_override: Optional[str] = None,
     ) -> ClaudeResponse:
         """Execute command via SDK."""
         return await self.sdk_manager.execute_command(
@@ -171,6 +181,8 @@ class ClaudeIntegration:
             stream_callback=stream_callback,
             interrupt_event=interrupt_event,
             images=images,
+            model_override=model_override,
+            effort_override=effort_override,
         )
 
     async def _find_resumable_session(

--- a/src/claude/monitor.py
+++ b/src/claude/monitor.py
@@ -1,8 +1,9 @@
-"""Bash directory boundary enforcement for Claude tool calls."""
+"""Bash directory boundary enforcement and git safety checks for Claude tool calls."""
 
+import re
 import shlex
 from pathlib import Path
-from typing import Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 # Subdirectories under ~/.claude/ that Claude Code uses internally.
 _CLAUDE_INTERNAL_SUBDIRS: Set[str] = {"plans", "todos", "settings.json"}
@@ -56,6 +57,22 @@ _FIND_MUTATING_ACTIONS: Set[str] = {"-delete", "-exec", "-execdir", "-ok", "-okd
 
 # Bash command separators
 _COMMAND_SEPARATORS: Set[str] = {"&&", "||", ";", "|", "&"}
+
+# ── Git safety regexes ────────────────────────────────────────────────────────
+# Matches any command that starts with "git"
+_GIT_COMMAND_RE = re.compile(r"^\s*git\s")
+
+# Force push: git push ... --force or -f (flag anywhere in args)
+_GIT_FORCE_PUSH_RE = re.compile(r"^\s*git\s+push\b.*(\s--force\b|\s-f\b)")
+
+# Branch force delete: git branch -D <name>  (uppercase D only)
+_GIT_BRANCH_DELETE_RE = re.compile(r"^\s*git\s+branch\b.*\s-D\b")
+
+# Hard reset: git reset --hard <ref>  — captures the ref token
+_GIT_RESET_HARD_RE = re.compile(r"^\s*git\s+reset\s+--hard\s+(\S+)")
+
+# Push subcommand start — used to extract positional args
+_GIT_PUSH_BRANCH_RE = re.compile(r"^\s*git\s+push\b")
 
 
 def check_bash_directory_boundary(
@@ -138,6 +155,81 @@ def check_bash_directory_boundary(
                 # using bash features we can't statically analyze.
                 # We skip checking this token and rely on the OS-level sandbox.
                 continue
+
+    return True, None
+
+
+def check_git_safety(
+    command: str,
+    protected_branches: List[str],
+    allow_force_push: bool,
+    allow_delete_branch: bool,
+) -> Tuple[bool, Optional[str]]:
+    """Check whether a git command violates configured safety rules.
+
+    Returns:
+        (True, None) if the command is allowed.
+        (False, error_message) if the command is blocked.
+
+    Only Bash tool commands that start with ``git`` are inspected; all other
+    commands pass through immediately.
+    """
+    # Early-exit: not a git command — nothing to check
+    if not _GIT_COMMAND_RE.match(command):
+        return True, None
+
+    # ── Force push ────────────────────────────────────────────────────────────
+    if not allow_force_push and _GIT_FORCE_PUSH_RE.match(command):
+        return False, (
+            "Operación git bloqueada: force-push deshabilitado. "
+            "Configurá GIT_ALLOW_FORCE_PUSH=true para habilitarlo."
+        )
+
+    # ── Force branch delete ───────────────────────────────────────────────────
+    if not allow_delete_branch and _GIT_BRANCH_DELETE_RE.match(command):
+        return False, (
+            "Operación git bloqueada: eliminación forzada de rama (git branch -D) "
+            "deshabilitada. Configurá GIT_ALLOW_DELETE_BRANCH=true para habilitarlo."
+        )
+
+    # ── Push to protected branch ──────────────────────────────────────────────
+    if protected_branches and _GIT_PUSH_BRANCH_RE.match(command):
+        # Tokenise the push command to extract positional (non-flag) args.
+        # git push [<remote>] [<branch>]  — the branch is the last positional arg.
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            tokens = command.split()
+
+        # Drop the leading "git" and "push" tokens
+        push_args = tokens[2:] if len(tokens) > 2 else []
+        positional = [t for t in push_args if not t.startswith("-")]
+
+        # The branch is the last positional arg (after optional remote)
+        candidate = positional[-1] if positional else None
+
+        if candidate:
+            for branch in protected_branches:
+                # Use whitespace-boundary anchors instead of \b so that hyphens
+                # inside branch names (e.g. "my-main-fix") do not produce false
+                # positives.  We compare the whole token instead.
+                if candidate == branch:
+                    return False, (
+                        f"Operación git bloqueada: push a rama protegida '{branch}'. "
+                        f"Las ramas protegidas son: {', '.join(protected_branches)}."
+                    )
+
+    # ── Hard reset to a protected ref ─────────────────────────────────────────
+    reset_match = _GIT_RESET_HARD_RE.match(command)
+    if reset_match:
+        ref = reset_match.group(1)
+        for branch in protected_branches:
+            # Match exact ref or remote/branch forms (e.g. origin/main)
+            if ref == branch or ref.endswith(f"/{branch}"):
+                return False, (
+                    f"Operación git bloqueada: reset --hard a ref protegida '{ref}'. "
+                    f"Las ramas protegidas son: {', '.join(protected_branches)}."
+                )
 
     return True, None
 

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -277,6 +277,8 @@ class ClaudeSDKManager:
         stream_callback: Optional[Callable[[StreamUpdate], None]] = None,
         interrupt_event: Optional[asyncio.Event] = None,
         images: Optional[List[Dict[str, str]]] = None,
+        model_override: Optional[str] = None,
+        effort_override: Optional[str] = None,
     ) -> ClaudeResponse:
         """Execute Claude Code command via SDK."""
         start_time = asyncio.get_event_loop().time()
@@ -321,7 +323,7 @@ class ClaudeSDKManager:
             # Build Claude Agent options
             options = ClaudeAgentOptions(
                 max_turns=self.config.claude_max_turns,
-                model=self.config.claude_model or None,
+                model=model_override or self.config.claude_model or None,
                 max_budget_usd=self.config.claude_max_cost_per_request,
                 cwd=str(working_directory),
                 allowed_tools=sdk_allowed_tools,
@@ -334,9 +336,17 @@ class ClaudeSDKManager:
                     "excludedCommands": self.config.sandbox_excluded_commands or [],
                 },
                 system_prompt=base_prompt,
+                effort=effort_override,
                 setting_sources=["project"],
                 stderr=_stderr_callback,
             )
+
+            if model_override or effort_override:
+                logger.info(
+                    "Runtime model/effort override active",
+                    model_override=model_override,
+                    effort_override=effort_override,
+                )
 
             # Pass MCP server configuration if enabled
             if self.config.enable_mcp and self.config.mcp_config_path:

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -326,7 +326,12 @@ class ClaudeSDKManager:
             # Build system prompt, loading CLAUDE.md from working directory if present
             base_prompt = (
                 f"All file operations must stay within {working_directory}. "
-                "Use relative paths."
+                "Use relative paths.\n\n"
+                "## Voice Replies\n"
+                "The bot layer automatically converts your text responses to voice notes when the user "
+                "has voice mode enabled. You do NOT need to do anything special. "
+                "Just respond normally with text — never mention TTS, edge-tts, scripts, sandbox, "
+                "or voice activation commands. Never say you cannot send voice."
             )
             claude_md_path = Path(working_directory) / "CLAUDE.md"
             if claude_md_path.exists():

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -428,6 +428,29 @@ class ClaudeSDKManager:
                     else:
                         await client.query(prompt)
 
+                    # -------------------------------------------------------------------------
+                    # NOTE: private API usage — intentional, with known trade-off.
+                    #
+                    # We iterate over `client._query.receive_messages()` (private) instead of
+                    # the public `client.receive_messages()` / `client.receive_response()`.
+                    #
+                    # Why: the public methods call `parse_message()` internally and swallow
+                    # `MessageParseError` silently (returning None and skipping). We need
+                    # explicit error logging per skipped message (lines below), which requires
+                    # access to the raw data before parsing.
+                    #
+                    # Equivalent public migration (if the raw-data requirement is dropped):
+                    #   async for message in client.receive_response():
+                    #       ...
+                    #       if isinstance(message, ResultMessage): break  # handled automatically
+                    #
+                    # ⚠ BREAKAGE RISK: `_query` is a private attribute of `ClaudeSDKClient`.
+                    # It is not part of the documented public API:
+                    #   https://code.claude.com/docs/en/agent-sdk/python
+                    # Anthropic may rename, remove, or restructure it in any SDK release
+                    # without a deprecation notice. If this loop stops working after an SDK
+                    # update (`claude-agent-sdk`), this block is the first place to check.
+                    # -------------------------------------------------------------------------
                     async for raw_data in client._query.receive_messages():
                         try:
                             message = parse_message(raw_data)

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -38,7 +38,11 @@ from .exceptions import (
     ClaudeProcessError,
     ClaudeTimeoutError,
 )
-from .monitor import _is_claude_internal_path, check_bash_directory_boundary
+from .monitor import (
+    _is_claude_internal_path,
+    check_bash_directory_boundary,
+    check_git_safety,
+)
 
 logger = structlog.get_logger()
 
@@ -181,11 +185,13 @@ def _make_can_use_tool_callback(
     security_validator: SecurityValidator,
     working_directory: Path,
     approved_directory: Path,
+    config: Optional[Settings] = None,
 ) -> Any:
     """Create a can_use_tool callback for SDK-level tool permission validation.
 
-    The callback validates file path boundaries and bash directory boundaries
-    *before* the SDK executes the tool, providing preventive security enforcement.
+    The callback validates file path boundaries, bash directory boundaries, and
+    git safety rules *before* the SDK executes the tool, providing preventive
+    security enforcement.
     """
     _FILE_TOOLS = {"Write", "Edit", "Read", "create_file", "edit_file", "read_file"}
     _BASH_TOOLS = {"Bash", "bash", "shell"}
@@ -232,6 +238,25 @@ def _make_can_use_tool_callback(
                     return PermissionResultDeny(
                         message=error or "Bash directory boundary violation"
                     )
+
+                # Git safety validation (after directory boundary check)
+                if config and not config.disable_tool_validation:
+                    git_ok, git_err = check_git_safety(
+                        command,
+                        config.git_protected_branches,
+                        config.git_allow_force_push,
+                        config.git_allow_delete_branch,
+                    )
+                    if not git_ok:
+                        logger.warning(
+                            "can_use_tool denied git operation",
+                            tool_name=tool_name,
+                            command=command,
+                            error=git_err,
+                        )
+                        return PermissionResultDeny(
+                            message=git_err or "Git operation blocked"
+                        )
 
         return PermissionResultAllow()
 
@@ -352,6 +377,7 @@ class ClaudeSDKManager:
                     security_validator=self.security_validator,
                     working_directory=working_directory,
                     approved_directory=self.config.approved_directory,
+                    config=self.config,
                 )
 
             # Resume previous session if we have a session_id

--- a/src/config/features.py
+++ b/src/config/features.py
@@ -87,6 +87,16 @@ class FeatureFlags:
         """Check if streaming drafts via sendMessageDraft is enabled."""
         return self.settings.enable_stream_drafts
 
+    @property
+    def sdd_enabled(self) -> bool:
+        """Check if the /sdd command is enabled."""
+        return self.settings.enable_sdd
+
+    @property
+    def voice_replies_enabled(self) -> bool:
+        """Check if outgoing voice TTS replies are enabled."""
+        return self.settings.enable_voice_replies
+
     def is_feature_enabled(self, feature_name: str) -> bool:
         """Generic feature check by name."""
         feature_map = {
@@ -103,6 +113,8 @@ class FeatureFlags:
             "agentic_mode": self.agentic_mode_enabled,
             "voice_messages": self.voice_messages_enabled,
             "stream_drafts": self.stream_drafts_enabled,
+            "sdd": self.sdd_enabled,
+            "voice_replies": self.voice_replies_enabled,
         }
         return feature_map.get(feature_name, False)
 
@@ -133,4 +145,8 @@ class FeatureFlags:
             features.append("voice_messages")
         if self.stream_drafts_enabled:
             features.append("stream_drafts")
+        if self.sdd_enabled:
+            features.append("sdd")
+        if self.voice_replies_enabled:
+            features.append("voice_replies")
         return features

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -264,6 +264,15 @@ class Settings(BaseSettings):
             "Named models resolve to ~/.cache/whisper-cpp/ggml-{name}.bin"
         ),
     )
+    whisper_cpp_language: str = Field(
+        "auto",
+        description=(
+            "Language hint passed to whisper.cpp via -l flag. "
+            "Use a whisper language code ('es', 'en', 'pt', etc.) or 'auto' for "
+            "automatic detection. Auto-detection is unreliable for short utterances "
+            "and may produce output in the wrong language."
+        ),
+    )
     # Voice TTS (text-to-speech outgoing replies)
     enable_voice_replies: bool = Field(
         False, description="Enable outgoing voice note replies via edge-tts"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -668,10 +668,8 @@ class Settings(BaseSettings):
                     "project_threads_chat_id required when "
                     "project_threads_mode is 'group'"
                 )
-            if not self.projects_config_path:
-                raise ValueError(
-                    "projects_config_path required when enable_project_threads is True"
-                )
+            # projects_config_path is optional — DB-only mode is valid
+            # (load_project_registry_from_db is used at startup when unset)
 
         return self
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from typing import Any, List, Literal, Optional
 
 from pydantic import Field, SecretStr, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings, EnvSettingsSource, SettingsConfigDict
 
 from src.utils.constants import (
     DEFAULT_CLAUDE_MAX_COST_PER_REQUEST,
@@ -284,6 +285,26 @@ class Settings(BaseSettings):
         "es-AR-TomasNeural",
         description="edge-tts voice name for TTS synthesis",
     )
+    tts_engine: Literal["edge-tts", "openai", "system"] = Field(
+        "edge-tts",
+        description=(
+            "TTS engine for outgoing voice replies: "
+            "'edge-tts' (default, CLI binary), "
+            "'openai' (OpenAI TTS API, requires OPENAI_API_KEY), "
+            "or 'system' (pyttsx3 offline, requires pip install pyttsx3)"
+        ),
+    )
+    openai_tts_voice: str = Field(
+        "nova",
+        description="OpenAI TTS voice name (used when VOICE_ENGINE=openai)",
+    )
+    system_tts_voice: str = Field(
+        "default",
+        description=(
+            "pyttsx3 voice ID (used when VOICE_ENGINE=system; "
+            "'default' uses the engine default)"
+        ),
+    )
 
     enable_quick_actions: bool = Field(True, description="Enable quick action buttons")
     agentic_mode: bool = Field(
@@ -401,6 +422,38 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
     )
+
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, **kwargs):  # type: ignore[override]
+        """Override env sources to handle comma-separated lists (pydantic-settings 2.x).
+
+        pydantic-settings 2.x tries json.loads() on List fields before field_validators run.
+        This override returns the raw string for comma-separated values so the existing
+        parse_protected_branches / parse_int_list validators can split them properly.
+        """
+        from pydantic_settings import DotEnvSettingsSource
+
+        def _patch(source_cls):  # type: ignore[no-untyped-def]
+            class _CommaFriendly(source_cls):  # type: ignore[valid-type]
+                def decode_complex_value(
+                    self, field_name: str, field: FieldInfo, value: Any
+                ) -> Any:
+                    if isinstance(value, str) and not value.strip().startswith(("[", "{")):
+                        return value  # let field_validator handle comma-separated
+                    return super().decode_complex_value(field_name, field, value)
+
+            return _CommaFriendly
+
+        sources = super().settings_customise_sources(settings_cls, **kwargs)
+        patched = []
+        for s in sources:
+            if type(s) is DotEnvSettingsSource:
+                patched.append(_patch(DotEnvSettingsSource)(settings_cls))
+            elif type(s) is EnvSettingsSource:
+                patched.append(_patch(EnvSettingsSource)(settings_cls))
+            else:
+                patched.append(s)
+        return tuple(patched)
 
     @field_validator("allowed_users", "notification_chat_ids", mode="before")
     @classmethod
@@ -547,6 +600,19 @@ class Settings(BaseSettings):
             raise ValueError("voice_reply_mode must be one of ['manual', 'auto']")
         return mode
 
+    @field_validator("tts_engine", mode="before")
+    @classmethod
+    def validate_tts_engine(cls, v: Any) -> str:
+        """Validate and normalize TTS engine selection."""
+        if v is None:
+            return "edge-tts"
+        engine = str(v).strip().lower()
+        if engine not in {"edge-tts", "openai", "system"}:
+            raise ValueError(
+                "tts_engine must be one of ['edge-tts', 'openai', 'system']"
+            )
+        return engine
+
     @field_validator("project_threads_chat_id", mode="before")
     @classmethod
     def validate_project_threads_chat_id(cls, v: Any) -> Optional[int]:
@@ -677,6 +743,15 @@ class Settings(BaseSettings):
         if self.voice_provider == "local":
             return "Local whisper.cpp"
         return "Mistral Voxtral"
+
+    @property
+    def tts_engine_display_name(self) -> str:
+        """Human-friendly label for the configured TTS engine."""
+        if self.tts_engine == "openai":
+            return "OpenAI TTS"
+        if self.tts_engine == "system":
+            return "System TTS (pyttsx3)"
+        return "edge-tts"
 
     @property
     def resolved_whisper_cpp_binary(self) -> str:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -67,6 +67,27 @@ class Settings(BaseSettings):
         description="Allow all Claude tools by bypassing tool validation checks",
     )
 
+    # Git safety
+    git_protected_branches: List[str] = Field(
+        default=["main", "develop", "master"],
+        description="Branches Claude cannot push to or reset --hard on",
+    )
+    git_allow_force_push: bool = Field(
+        False,
+        description="Allow git push --force / -f (default: blocked)",
+    )
+    git_allow_delete_branch: bool = Field(
+        False,
+        description="Allow git branch -D (force-delete) (default: blocked)",
+    )
+
+    # SDD command
+    enable_sdd: bool = Field(True, description="Enable /sdd command")
+    sdd_protected_branches: List[str] = Field(
+        default=["main", "master", "develop"],
+        description="Branches /sdd must never push to",
+    )
+
     # Claude settings
     claude_binary_path: Optional[str] = Field(
         None, description="Path to Claude CLI binary (deprecated)"
@@ -242,6 +263,28 @@ class Settings(BaseSettings):
             "Named models resolve to ~/.cache/whisper-cpp/ggml-{name}.bin"
         ),
     )
+    # Voice TTS (text-to-speech outgoing replies)
+    enable_voice_replies: bool = Field(
+        False, description="Enable outgoing voice note replies via edge-tts"
+    )
+    voice_reply_mode: Literal["manual", "auto"] = Field(
+        "manual",
+        description=(
+            "Voice reply mode: 'manual' (always voice when enabled via /voice on) "
+            "or 'auto' (voice only when reply is short enough)"
+        ),
+    )
+    voice_reply_max_words: int = Field(
+        200,
+        ge=1,
+        le=500,
+        description="Maximum word count for auto voice mode",
+    )
+    edge_tts_voice: str = Field(
+        "es-AR-TomasNeural",
+        description="edge-tts voice name for TTS synthesis",
+    )
+
     enable_quick_actions: bool = Field(True, description="Enable quick action buttons")
     agentic_mode: bool = Field(
         True,
@@ -308,6 +351,31 @@ class Settings(BaseSettings):
     notification_chat_ids: Optional[List[int]] = Field(
         None, description="Default Telegram chat IDs for proactive notifications"
     )
+    # GitHub issues webhook — automatic SDD trigger
+    enable_issue_webhook: bool = Field(
+        False,
+        description=(
+            "Auto-trigger SDD analysis when a GitHub issue is opened or labeled"
+        ),
+    )
+    issue_webhook_require_label: bool = Field(
+        True,
+        description=(
+            "When True, only issues that carry issue_webhook_label are processed"
+        ),
+    )
+    issue_webhook_label: str = Field(
+        "sdd-analyze",
+        description="GitHub label that triggers automatic SDD analysis",
+    )
+    issue_webhook_repo_allowlist: List[str] = Field(
+        default=[],
+        description=(
+            "Repos allowed to trigger analysis (owner/repo format). "
+            "Empty list means all repos are allowed."
+        ),
+    )
+
     enable_project_threads: bool = Field(
         False,
         description="Enable strict routing by Telegram forum project threads",
@@ -358,6 +426,26 @@ class Settings(BaseSettings):
             return [tool.strip() for tool in v.split(",") if tool.strip()]
         if isinstance(v, list):
             return [str(tool) for tool in v]
+        return v  # type: ignore[no-any-return]
+
+    @field_validator("issue_webhook_repo_allowlist", mode="before")
+    @classmethod
+    def parse_repo_allowlist(cls, v: Any) -> List[str]:
+        """Parse comma-separated repo allowlist from env var string."""
+        if isinstance(v, str):
+            return [r.strip() for r in v.split(",") if r.strip()]
+        if isinstance(v, list):
+            return [str(r) for r in v]
+        return v  # type: ignore[no-any-return]
+
+    @field_validator("git_protected_branches", "sdd_protected_branches", mode="before")
+    @classmethod
+    def parse_protected_branches(cls, v: Any) -> List[str]:
+        """Parse comma-separated branch names from env var string."""
+        if isinstance(v, str):
+            return [b.strip() for b in v.split(",") if b.strip()]
+        if isinstance(v, list):
+            return [str(b) for b in v]
         return v  # type: ignore[no-any-return]
 
     @field_validator("approved_directory")
@@ -447,6 +535,17 @@ class Settings(BaseSettings):
                 "voice_provider must be one of ['mistral', 'openai', 'local']"
             )
         return provider
+
+    @field_validator("voice_reply_mode", mode="before")
+    @classmethod
+    def validate_voice_reply_mode(cls, v: Any) -> str:
+        """Validate and normalize voice reply mode."""
+        if v is None:
+            return "manual"
+        mode = str(v).strip().lower()
+        if mode not in {"manual", "auto"}:
+            raise ValueError("voice_reply_mode must be one of ['manual', 'auto']")
+        return mode
 
     @field_validator("project_threads_chat_id", mode="before")
     @classmethod

--- a/src/events/handlers.py
+++ b/src/events/handlers.py
@@ -4,8 +4,9 @@ AgentHandler: translates events into ClaudeIntegration.run_command() calls.
 NotificationHandler: subscribes to AgentResponseEvent and delivers to Telegram.
 """
 
+import asyncio
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 import structlog
 
@@ -35,6 +36,8 @@ class AgentHandler:
         self.claude = claude_integration
         self.default_working_directory = default_working_directory
         self.default_user_id = default_user_id
+        self._scheduled_semaphore = asyncio.Semaphore(2)
+        self._background_tasks: Set[asyncio.Task[Any]] = set()
 
     def register(self) -> None:
         """Subscribe to events that need agent processing."""
@@ -92,15 +95,27 @@ class AgentHandler:
             job_name=event.job_name,
         )
 
-        prompt = event.prompt
-        if event.skill_name:
-            prompt = (
-                f"/{event.skill_name}\n\n{prompt}" if prompt else f"/{event.skill_name}"
-            )
+        task = asyncio.create_task(
+            self._run_scheduled(event),
+            name=f"scheduled:{event.job_id or event.job_name or event.id}",
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._task_done)
+        await asyncio.sleep(0)
 
-        working_dir = event.working_directory or self.default_working_directory
+    async def _run_scheduled(self, event: ScheduledEvent) -> None:
+        """Run scheduled Claude work in the background with concurrency limits."""
+        async with self._scheduled_semaphore:
+            prompt = event.prompt
+            if event.skill_name:
+                prompt = (
+                    f"/{event.skill_name}\n\n{prompt}"
+                    if prompt
+                    else f"/{event.skill_name}"
+                )
 
-        try:
+            working_dir = event.working_directory or self.default_working_directory
+
             response = await self.claude.run_command(
                 prompt=prompt,
                 working_directory=working_dir,
@@ -126,11 +141,18 @@ class AgentHandler:
                             originating_event_id=event.id,
                         )
                     )
+
+    def _task_done(self, task: asyncio.Task[Any]) -> None:
+        """Clean up finished scheduled tasks and log failures."""
+        self._background_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
         except Exception:
             logger.exception(
                 "Agent execution failed for scheduled event",
-                job_id=event.job_id,
-                event_id=event.id,
+                task_name=task.get_name(),
             )
 
     def _build_webhook_prompt(self, event: WebhookEvent) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,11 @@ from src.events.handlers import AgentHandler
 from src.events.middleware import EventSecurityMiddleware
 from src.exceptions import ConfigurationError
 from src.notifications.service import NotificationService
-from src.projects import ProjectThreadManager, load_project_registry
+from src.projects import (
+    ProjectThreadManager,
+    load_project_registry,
+    load_project_registry_from_db,
+)
 from src.scheduler.scheduler import JobScheduler
 from src.security.audit import AuditLogger, InMemoryAuditStorage
 from src.security.auth import (
@@ -237,14 +241,17 @@ async def run_application(app: Dict[str, Any]) -> None:
         await bot.initialize()
 
         if config.enable_project_threads:
-            if not config.projects_config_path:
-                raise ConfigurationError(
-                    "Project thread mode enabled but required settings are missing"
+            if config.projects_config_path:
+                registry = load_project_registry(
+                    config_path=config.projects_config_path,
+                    approved_directory=config.approved_directory,
                 )
-            registry = load_project_registry(
-                config_path=config.projects_config_path,
-                approved_directory=config.approved_directory,
-            )
+            else:
+                registry = await load_project_registry_from_db(
+                    repo=storage.projects,
+                    approved_directory=config.approved_directory,
+                    chat_id=config.project_threads_chat_id,
+                )
             project_threads_manager = ProjectThreadManager(
                 registry=registry,
                 repository=storage.project_threads,

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import logging
+import shutil
 import signal
 import sys
 from pathlib import Path
@@ -366,10 +367,29 @@ async def run_application(app: Dict[str, Any]) -> None:
         logger.info("Application shutdown complete")
 
 
+def _check_claude_cli() -> None:
+    """Fail fast if the Claude Code CLI is not available on PATH.
+
+    claude-agent-sdk invokes ``claude`` as a subprocess. If the binary is
+    missing the bot will fail on the first user message with a cryptic error.
+    Detecting this at startup gives a clear, actionable error message instead.
+    """
+    logger = structlog.get_logger()
+    if shutil.which("claude") is None:
+        logger.error(
+            "claude CLI not found on PATH — claude-agent-sdk requires it. "
+            "Install with: npm install -g @anthropic-ai/claude-code"
+        )
+        sys.exit(1)
+
+
 async def main() -> None:
     """Main application entry point."""
     args = parse_args()
     setup_logging(debug=args.debug)
+
+    # Fail fast if Claude Code CLI is missing (required by claude-agent-sdk)
+    _check_claude_cli()
 
     logger = structlog.get_logger()
     logger.info("Starting Claude Code Telegram Bot", version=__version__)

--- a/src/main.py
+++ b/src/main.py
@@ -181,6 +181,7 @@ async def create_application(config: Settings) -> Dict[str, Any]:
         "event_bus": event_bus,
         "project_registry": None,
         "project_threads_manager": None,
+        "scheduler": None,
     }
 
     bot = ClaudeCodeBot(config, dependencies)
@@ -314,6 +315,7 @@ async def run_application(app: Dict[str, Any]) -> None:
                 default_working_directory=config.approved_directory,
             )
             await scheduler.start()
+            bot.deps["scheduler"] = scheduler
             logger.info("Job scheduler enabled")
 
         # Shutdown task

--- a/src/projects/__init__.py
+++ b/src/projects/__init__.py
@@ -1,6 +1,11 @@
 """Project registry and Telegram thread management."""
 
-from .registry import ProjectDefinition, ProjectRegistry, load_project_registry
+from .registry import (
+    ProjectDefinition,
+    ProjectRegistry,
+    load_project_registry,
+    load_project_registry_from_db,
+)
 from .thread_manager import (
     PrivateTopicsUnavailableError,
     ProjectThreadManager,
@@ -10,6 +15,7 @@ __all__ = [
     "ProjectDefinition",
     "ProjectRegistry",
     "load_project_registry",
+    "load_project_registry_from_db",
     "ProjectThreadManager",
     "PrivateTopicsUnavailableError",
 ]

--- a/src/projects/registry.py
+++ b/src/projects/registry.py
@@ -1,10 +1,18 @@
 """YAML-backed project registry for thread mode."""
 
+from __future__ import annotations
+
+import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import yaml
+
+if TYPE_CHECKING:
+    from src.storage.repositories import ProjectRepository
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -16,6 +24,7 @@ class ProjectDefinition:
     relative_path: Path
     absolute_path: Path
     enabled: bool = True
+    git_url: Optional[str] = None
 
 
 class ProjectRegistry:
@@ -116,6 +125,59 @@ def load_project_registry(
                 relative_path=rel_path,
                 absolute_path=absolute_path,
                 enabled=enabled,
+            )
+        )
+
+    return ProjectRegistry(projects)
+
+
+async def load_project_registry_from_db(
+    repo: "ProjectRepository",
+    approved_directory: Path,
+    chat_id: Optional[int] = None,
+) -> ProjectRegistry:
+    """Load and validate project definitions from the database.
+
+    Args:
+        repo: ProjectRepository instance for DB access
+        approved_directory: Approved base directory for path validation
+        chat_id: If provided, load projects for this chat only.
+                 If None, load all enabled projects.
+
+    Returns:
+        ProjectRegistry built from DB rows with validated paths.
+        Rows whose absolute_path falls outside approved_directory are
+        skipped with a warning.
+    """
+    if chat_id is not None:
+        rows = await repo.list_by_chat(chat_id, enabled_only=True)
+    else:
+        rows = await repo.list_all_enabled()
+
+    approved_root = approved_directory.resolve()
+    projects: List[ProjectDefinition] = []
+
+    for row in rows:
+        abs_path = Path(row.absolute_path).resolve()
+        try:
+            rel_path = abs_path.relative_to(approved_root)
+        except ValueError:
+            logger.warning(
+                "Project path outside approved directory — skipping",
+                project_slug=row.project_slug,
+                absolute_path=row.absolute_path,
+                approved_directory=str(approved_root),
+            )
+            continue
+
+        projects.append(
+            ProjectDefinition(
+                slug=row.project_slug,
+                name=row.name,
+                relative_path=rel_path,
+                absolute_path=abs_path,
+                enabled=row.enabled,
+                git_url=row.git_url,
             )
         )
 

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -121,12 +121,89 @@ class JobScheduler:
         logger.info("Scheduled job removed", job_id=job_id)
         return True
 
-    async def list_jobs(self) -> List[Dict[str, Any]]:
-        """List all scheduled jobs from the database."""
+    async def pause_job(self, job_id: str) -> bool:
+        """Pause a scheduled job (remove from APScheduler, mark inactive in DB)."""
+        try:
+            self._scheduler.remove_job(job_id)
+        except Exception:
+            logger.warning("Job not found in scheduler", job_id=job_id)
+
         async with self.db_manager.get_connection() as conn:
             cursor = await conn.execute(
-                "SELECT * FROM scheduled_jobs WHERE is_active = 1 ORDER BY created_at"
+                "UPDATE scheduled_jobs SET is_active = 0 WHERE job_id = ?",
+                (job_id,),
             )
+            await conn.commit()
+            if cursor.rowcount == 0:
+                return False
+
+        logger.info("Scheduled job paused", job_id=job_id)
+        return True
+
+    async def resume_job(self, job_id: str) -> bool:
+        """Resume a paused job (re-register with APScheduler, mark active in DB)."""
+        async with self.db_manager.get_connection() as conn:
+            cursor = await conn.execute(
+                "SELECT * FROM scheduled_jobs WHERE job_id = ?",
+                (job_id,),
+            )
+            row = await cursor.fetchone()
+
+        if not row:
+            return False
+
+        row_dict = dict(row)
+
+        # Re-register with APScheduler
+        try:
+            trigger = CronTrigger.from_crontab(row_dict["cron_expression"])
+            chat_ids_str = row_dict.get("target_chat_ids", "")
+            chat_ids = (
+                [int(x) for x in chat_ids_str.split(",") if x.strip()]
+                if chat_ids_str
+                else []
+            )
+            self._scheduler.add_job(
+                self._fire_event,
+                trigger=trigger,
+                kwargs={
+                    "job_name": row_dict["job_name"],
+                    "prompt": row_dict["prompt"],
+                    "working_directory": row_dict["working_directory"],
+                    "target_chat_ids": chat_ids,
+                    "skill_name": row_dict.get("skill_name"),
+                },
+                id=job_id,
+                name=row_dict["job_name"],
+                replace_existing=True,
+            )
+        except Exception:
+            logger.exception("Failed to re-register job with scheduler", job_id=job_id)
+            return False
+
+        # Mark active in DB
+        async with self.db_manager.get_connection() as conn:
+            await conn.execute(
+                "UPDATE scheduled_jobs SET is_active = 1 WHERE job_id = ?",
+                (job_id,),
+            )
+            await conn.commit()
+
+        logger.info("Scheduled job resumed", job_id=job_id)
+        return True
+
+    async def list_jobs(self, include_paused: bool = False) -> List[Dict[str, Any]]:
+        """List scheduled jobs from the database."""
+        async with self.db_manager.get_connection() as conn:
+            if include_paused:
+                cursor = await conn.execute(
+                    "SELECT * FROM scheduled_jobs ORDER BY created_at"
+                )
+            else:
+                cursor = await conn.execute(
+                    "SELECT * FROM scheduled_jobs"
+                    " WHERE is_active = 1 ORDER BY created_at"
+                )
             rows = await cursor.fetchall()
             return [dict(row) for row in rows]
 

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -32,7 +32,12 @@ class JobScheduler:
         self.event_bus = event_bus
         self.db_manager = db_manager
         self.default_working_directory = default_working_directory
-        self._scheduler = AsyncIOScheduler()
+        self._scheduler = AsyncIOScheduler(
+            job_defaults={
+                "misfire_grace_time": None,  # Always run, no matter how late
+                "coalesce": True,            # Merge multiple missed runs into one
+            }
+        )
 
     async def start(self) -> None:
         """Load persisted jobs and start the scheduler."""

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -310,6 +310,27 @@ class DatabaseManager:
                     ON project_threads(project_slug);
                 """,
             ),
+            (
+                5,
+                """
+                -- Dynamic project registry for /topics command
+                CREATE TABLE IF NOT EXISTS projects (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    project_slug TEXT NOT NULL,
+                    chat_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    absolute_path TEXT NOT NULL,
+                    git_url TEXT,
+                    enabled BOOLEAN DEFAULT TRUE,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(chat_id, project_slug)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_projects_chat_active
+                    ON projects(chat_id, enabled);
+                """,
+            ),
         ]
 
     async def _init_pool(self):

--- a/src/storage/facade.py
+++ b/src/storage/facade.py
@@ -22,6 +22,7 @@ from .repositories import (
     AuditLogRepository,
     CostTrackingRepository,
     MessageRepository,
+    ProjectRepository,
     ProjectThreadRepository,
     SessionRepository,
     ToolUsageRepository,
@@ -40,6 +41,7 @@ class Storage:
         self.users = UserRepository(self.db_manager)
         self.sessions = SessionRepository(self.db_manager)
         self.project_threads = ProjectThreadRepository(self.db_manager)
+        self.projects = ProjectRepository(self.db_manager)
         self.messages = MessageRepository(self.db_manager)
         self.tools = ToolUsageRepository(self.db_manager)
         self.audit = AuditLogRepository(self.db_manager)

--- a/src/storage/models.py
+++ b/src/storage/models.py
@@ -139,6 +139,44 @@ class ProjectThreadModel:
 
 
 @dataclass
+class ProjectModel:
+    """Dynamic project registry data model."""
+
+    project_slug: str
+    chat_id: int
+    name: str
+    absolute_path: str
+    git_url: Optional[str] = None
+    enabled: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    id: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        data = asdict(self)
+        for key in ["created_at", "updated_at"]:
+            if data[key]:
+                data[key] = data[key].isoformat()
+        return data
+
+    @classmethod
+    def from_row(cls, row: aiosqlite.Row) -> "ProjectModel":
+        """Create from database row."""
+        data = dict(row)
+
+        for field in ["created_at", "updated_at"]:
+            val = data.get(field)
+            if val and isinstance(val, str):
+                data[field] = datetime.fromisoformat(val)
+            elif val and not isinstance(val, datetime):
+                data[field] = _parse_datetime(val)
+        data["enabled"] = bool(data.get("enabled", True))
+
+        return cls(**data)
+
+
+@dataclass
 class MessageModel:
     """Message data model."""
 

--- a/src/storage/repositories.py
+++ b/src/storage/repositories.py
@@ -17,6 +17,7 @@ from .models import (
     AuditLogModel,
     CostTrackingModel,
     MessageModel,
+    ProjectModel,
     ProjectThreadModel,
     SessionModel,
     ToolUsageModel,
@@ -380,6 +381,94 @@ class ProjectThreadRepository:
             cursor = await conn.execute(query, params)
             rows = await cursor.fetchall()
             return [ProjectThreadModel.from_row(row) for row in rows]
+
+
+class ProjectRepository:
+    """Dynamic project registry data access."""
+
+    def __init__(self, db_manager: DatabaseManager):
+        """Initialize repository."""
+        self.db = db_manager
+
+    async def upsert(
+        self,
+        project_slug: str,
+        chat_id: int,
+        name: str,
+        absolute_path: str,
+        git_url: Optional[str] = None,
+        enabled: bool = True,
+    ) -> ProjectModel:
+        """Create or update a project entry."""
+        async with self.db.get_connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO projects (
+                    project_slug, chat_id, name, absolute_path, git_url, enabled
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(chat_id, project_slug) DO UPDATE SET
+                    name = excluded.name,
+                    absolute_path = excluded.absolute_path,
+                    git_url = excluded.git_url,
+                    enabled = excluded.enabled,
+                    updated_at = CURRENT_TIMESTAMP
+            """,
+                (project_slug, chat_id, name, absolute_path, git_url, enabled),
+            )
+            await conn.commit()
+
+        result = await self.get_by_slug(project_slug, chat_id)
+        if not result:
+            raise RuntimeError("Failed to upsert project")
+        return result
+
+    async def get_by_slug(
+        self, project_slug: str, chat_id: int
+    ) -> Optional[ProjectModel]:
+        """Find project by slug and chat."""
+        async with self.db.get_connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT * FROM projects
+                WHERE project_slug = ? AND chat_id = ?
+            """,
+                (project_slug, chat_id),
+            )
+            row = await cursor.fetchone()
+            return ProjectModel.from_row(row) if row else None
+
+    async def list_by_chat(
+        self, chat_id: int, enabled_only: bool = True
+    ) -> List[ProjectModel]:
+        """List projects for a chat, ordered by slug."""
+        async with self.db.get_connection() as conn:
+            query = "SELECT * FROM projects WHERE chat_id = ?"
+            params: List = [chat_id]
+            if enabled_only:
+                query += " AND enabled = TRUE"
+            query += " ORDER BY project_slug ASC"
+            cursor = await conn.execute(query, params)
+            rows = await cursor.fetchall()
+            return [ProjectModel.from_row(row) for row in rows]
+
+    async def list_all_enabled(self) -> List[ProjectModel]:
+        """List all enabled projects across all chats."""
+        async with self.db.get_connection() as conn:
+            cursor = await conn.execute(
+                "SELECT * FROM projects WHERE enabled = TRUE ORDER BY project_slug ASC"
+            )
+            rows = await cursor.fetchall()
+            return [ProjectModel.from_row(row) for row in rows]
+
+    async def delete(self, project_slug: str, chat_id: int) -> int:
+        """Delete a project by slug and chat. Returns rowcount (0 if not found)."""
+        async with self.db.get_connection() as conn:
+            cursor = await conn.execute(
+                "DELETE FROM projects WHERE project_slug = ? AND chat_id = ?",
+                (project_slug, chat_id),
+            )
+            await conn.commit()
+            return cursor.rowcount
 
 
 class MessageRepository:

--- a/tests/unit/features/test_voice_sender.py
+++ b/tests/unit/features/test_voice_sender.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.bot.features.voice_handler import VoiceSender
+from src.bot.features.registry import _pyttsx3_importable
 
 
 # ---------------------------------------------------------------------------
@@ -191,3 +192,265 @@ async def test_send_voice_reply_failure_returns_false(voice_sender, tmp_path):
     # Temp dirs must still be cleaned up even on failure
     for d in captured_tmp_dirs:
         assert not Path(d).exists(), f"Temp dir {d} leaked on failure"
+
+
+# ---------------------------------------------------------------------------
+# OpenAI engine fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def openai_tts_config():
+    """Mock Settings configured for the openai TTS engine."""
+    cfg = MagicMock()
+    cfg.tts_engine = "openai"
+    cfg.openai_tts_voice = "nova"
+    cfg.openai_api_key = MagicMock()
+    cfg.openai_api_key_str = "sk-test"
+    cfg.edge_tts_voice = "es-AR-TomasNeural"
+    cfg.voice_reply_max_words = 200
+    return cfg
+
+
+@pytest.fixture
+def openai_voice_sender(openai_tts_config):
+    """VoiceSender instance configured for OpenAI engine."""
+    return VoiceSender(config=openai_tts_config)
+
+
+# ---------------------------------------------------------------------------
+# 4.2 OpenAI engine — success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_openai_success(openai_voice_sender, tmp_path):
+    """_synthesize_ogg_openai returns an OGG path on success (mocked API + ffmpeg)."""
+    # Mock OpenAI response
+    mock_response = MagicMock()
+    mock_response.content = b"fake-mp3-bytes"
+
+    mock_openai_client = AsyncMock()
+    mock_openai_client.audio.speech.create = AsyncMock(return_value=mock_response)
+
+    good_ffmpeg_proc = _make_process(returncode=0)
+
+    with (
+        patch.object(
+            openai_voice_sender, "_get_openai_tts_client", return_value=mock_openai_client
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=good_ffmpeg_proc)),
+    ):
+        result = await openai_voice_sender._synthesize_ogg_openai("Hello world", tmp_path)
+
+    assert isinstance(result, Path)
+    assert result.name == "reply.ogg"
+    mock_openai_client.audio.speech.create.assert_awaited_once()
+    call_kwargs = mock_openai_client.audio.speech.create.call_args[1]
+    assert call_kwargs["voice"] == "nova"
+    assert call_kwargs["model"] == "tts-1"
+    assert call_kwargs["input"] == "Hello world"
+
+
+# ---------------------------------------------------------------------------
+# 4.3 OpenAI engine — ffmpeg missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_openai_ffmpeg_missing(openai_voice_sender, tmp_path):
+    """_synthesize_ogg_openai raises RuntimeError with install hint when ffmpeg absent."""
+    mock_response = MagicMock()
+    mock_response.content = b"fake-mp3-bytes"
+
+    mock_openai_client = AsyncMock()
+    mock_openai_client.audio.speech.create = AsyncMock(return_value=mock_response)
+
+    with (
+        patch.object(
+            openai_voice_sender, "_get_openai_tts_client", return_value=mock_openai_client
+        ),
+        patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("ffmpeg"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="ffmpeg"):
+            await openai_voice_sender._synthesize_ogg_openai("Hello", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# System engine fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def system_tts_config():
+    """Mock Settings configured for the system (pyttsx3) TTS engine."""
+    cfg = MagicMock()
+    cfg.tts_engine = "system"
+    cfg.system_tts_voice = "default"
+    cfg.edge_tts_voice = "es-AR-TomasNeural"
+    cfg.voice_reply_max_words = 200
+    return cfg
+
+
+@pytest.fixture
+def system_voice_sender(system_tts_config):
+    """VoiceSender instance configured for system engine."""
+    return VoiceSender(config=system_tts_config)
+
+
+# ---------------------------------------------------------------------------
+# 4.5 System engine — success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_system_success(system_voice_sender, tmp_path):
+    """_synthesize_ogg_system returns an OGG path; pyttsx3 runs via asyncio.to_thread."""
+    mock_pyttsx3_engine = MagicMock()
+
+    mock_pyttsx3 = MagicMock()
+    mock_pyttsx3.init.return_value = mock_pyttsx3_engine
+
+    good_ffmpeg_proc = _make_process(returncode=0)
+
+    to_thread_called = []
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        to_thread_called.append(True)
+        fn()  # run synchronously in test for simplicity
+
+    with (
+        patch.dict("sys.modules", {"pyttsx3": mock_pyttsx3}),
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=good_ffmpeg_proc)),
+    ):
+        result = await system_voice_sender._synthesize_ogg_system("Hello world", tmp_path)
+
+    assert isinstance(result, Path)
+    assert result.name == "reply.ogg"
+    assert len(to_thread_called) == 1, "pyttsx3 must run inside asyncio.to_thread"
+    mock_pyttsx3.init.assert_called_once()
+    mock_pyttsx3_engine.save_to_file.assert_called_once()
+    mock_pyttsx3_engine.runAndWait.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 4.6 System engine — pyttsx3 not installed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_system_pyttsx3_missing(system_voice_sender, tmp_path):
+    """_synthesize_ogg_system raises RuntimeError with install hint when pyttsx3 absent."""
+    import sys
+
+    # Remove pyttsx3 from sys.modules and make import fail
+    with patch.dict("sys.modules", {"pyttsx3": None}):  # type: ignore[dict-item]
+        with pytest.raises(RuntimeError, match="pyttsx3"):
+            await system_voice_sender._synthesize_ogg_system("Hello", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 4.7 Dispatcher routes to openai engine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_dispatcher_routes_openai(openai_voice_sender, tmp_path):
+    """_synthesize_ogg delegates to _synthesize_ogg_openai when tts_engine='openai'."""
+    expected_path = tmp_path / "reply.ogg"
+
+    with patch.object(
+        openai_voice_sender,
+        "_synthesize_ogg_openai",
+        new_callable=AsyncMock,
+        return_value=expected_path,
+    ) as mock_openai:
+        result = await openai_voice_sender._synthesize_ogg("Hello", tmp_path)
+
+    mock_openai.assert_awaited_once_with("Hello", tmp_path)
+    assert result == expected_path
+
+
+# ---------------------------------------------------------------------------
+# 4.8 Dispatcher routes to system engine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_dispatcher_routes_system(system_voice_sender, tmp_path):
+    """_synthesize_ogg delegates to _synthesize_ogg_system when tts_engine='system'."""
+    expected_path = tmp_path / "reply.ogg"
+
+    with patch.object(
+        system_voice_sender,
+        "_synthesize_ogg_system",
+        new_callable=AsyncMock,
+        return_value=expected_path,
+    ) as mock_system:
+        result = await system_voice_sender._synthesize_ogg("Hello", tmp_path)
+
+    mock_system.assert_awaited_once_with("Hello", tmp_path)
+    assert result == expected_path
+
+
+# ---------------------------------------------------------------------------
+# 4.9 Registry guard — openai engine, no API key → voice_sender absent
+# ---------------------------------------------------------------------------
+
+
+def test_registry_skips_voice_sender_openai_no_key():
+    """FeatureRegistry skips voice_sender when tts_engine=openai but no API key."""
+    from src.bot.features.registry import FeatureRegistry
+
+    config = MagicMock()
+    config.enable_file_uploads = False
+    config.enable_git_integration = False
+    config.enable_quick_actions = False
+    config.agentic_mode = True
+    config.enable_voice_messages = False
+    config.enable_voice_replies = True
+    config.tts_engine = "openai"
+    config.openai_api_key = None  # missing key
+
+    storage = MagicMock()
+    security = MagicMock()
+
+    # ImageHandler needs real config attrs — patch it out
+    with patch("src.bot.features.registry.ImageHandler"):
+        registry = FeatureRegistry(config=config, storage=storage, security=security)
+
+    assert "voice_sender" not in registry.features
+
+
+# ---------------------------------------------------------------------------
+# 4.10 Registry guard — system engine, pyttsx3 not importable → voice_sender absent
+# ---------------------------------------------------------------------------
+
+
+def test_registry_skips_voice_sender_system_no_pyttsx3():
+    """FeatureRegistry skips voice_sender when tts_engine=system and pyttsx3 missing."""
+    from src.bot.features.registry import FeatureRegistry
+
+    config = MagicMock()
+    config.enable_file_uploads = False
+    config.enable_git_integration = False
+    config.enable_quick_actions = False
+    config.agentic_mode = True
+    config.enable_voice_messages = False
+    config.enable_voice_replies = True
+    config.tts_engine = "system"
+
+    storage = MagicMock()
+    security = MagicMock()
+
+    with (
+        patch("src.bot.features.registry.ImageHandler"),
+        patch("src.bot.features.registry._pyttsx3_importable", return_value=False),
+    ):
+        registry = FeatureRegistry(config=config, storage=storage, security=security)
+
+    assert "voice_sender" not in registry.features

--- a/tests/unit/features/test_voice_sender.py
+++ b/tests/unit/features/test_voice_sender.py
@@ -1,0 +1,193 @@
+"""Tests for VoiceSender (TTS outgoing voice replies)."""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.bot.features.voice_handler import VoiceSender
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tts_config():
+    """Mock Settings for VoiceSender tests."""
+    cfg = MagicMock()
+    cfg.edge_tts_voice = "es-AR-TomasNeural"
+    cfg.voice_reply_max_words = 200
+    return cfg
+
+
+@pytest.fixture
+def voice_sender(tts_config):
+    """VoiceSender instance under test."""
+    return VoiceSender(config=tts_config)
+
+
+def _make_process(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""):
+    """Build a mock asyncio.Process whose communicate() returns (stdout, stderr)."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.kill = MagicMock()
+    return proc
+
+
+def _make_update(reply_voice_mock: AsyncMock | None = None) -> MagicMock:
+    """Build a minimal mock Update with message.reply_voice."""
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.reply_voice = reply_voice_mock or AsyncMock()
+    return update
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_ogg — success path (4.1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_success(voice_sender, tmp_path):
+    """_synthesize_ogg returns a Path when edge-tts exits 0."""
+    good_proc = _make_process(returncode=0)
+
+    with patch(
+        "asyncio.create_subprocess_exec", AsyncMock(return_value=good_proc)
+    ) as mock_exec:
+        result = await voice_sender._synthesize_ogg("Hello world", tmp_path)
+
+    assert isinstance(result, Path)
+    assert result.name == "reply.ogg"
+    assert result.parent == tmp_path
+    mock_exec.assert_called_once()
+    # Verify voice name is passed
+    call_args = mock_exec.call_args[0]
+    assert "es-AR-TomasNeural" in call_args
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_ogg — non-zero exit raises RuntimeError (4.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_nonzero_exit_raises(voice_sender, tmp_path):
+    """_synthesize_ogg raises RuntimeError when edge-tts returns non-zero exit code."""
+    fail_proc = _make_process(returncode=1, stderr=b"error: voice not found")
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fail_proc)):
+        with pytest.raises(RuntimeError, match="synthesis failed"):
+            await voice_sender._synthesize_ogg("Hello", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_ogg — FileNotFoundError raises RuntimeError with install hint (4.3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_binary_missing_raises(voice_sender, tmp_path):
+    """_synthesize_ogg raises RuntimeError with install hint when edge-tts not on PATH."""
+    with patch(
+        "asyncio.create_subprocess_exec", side_effect=FileNotFoundError("edge-tts")
+    ):
+        with pytest.raises(RuntimeError, match="pip install edge-tts"):
+            await voice_sender._synthesize_ogg("Hello", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_ogg — timeout kills process and raises RuntimeError (4.4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_ogg_timeout_kills_process(voice_sender, tmp_path):
+    """_synthesize_ogg kills the process and raises RuntimeError on timeout."""
+    slow_proc = _make_process(returncode=0)
+    slow_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=slow_proc)):
+        with pytest.raises(RuntimeError, match="timed out"):
+            await voice_sender._synthesize_ogg("Hello", tmp_path)
+
+    slow_proc.kill.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# send_voice_reply — success path: temp dir cleaned up (4.5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reply_success_cleans_tmp(voice_sender, tmp_path):
+    """send_voice_reply returns True and cleans up temp dir after successful send."""
+    good_proc = _make_process(returncode=0)
+    reply_voice = AsyncMock()
+    update = _make_update(reply_voice_mock=reply_voice)
+
+    # Patch _synthesize_ogg to write a real (empty) file so open() works
+    async def fake_synthesize(text: str, td: Path) -> Path:
+        p = td / "reply.ogg"
+        p.write_bytes(b"fake-ogg-data")
+        return p
+
+    captured_tmp_dirs: list = []
+
+    original_mkdtemp = __import__("tempfile").mkdtemp
+
+    def patched_mkdtemp(**kwargs):  # type: ignore[return]
+        d = original_mkdtemp(**kwargs)
+        captured_tmp_dirs.append(d)
+        return d
+
+    with (
+        patch.object(voice_sender, "_synthesize_ogg", side_effect=fake_synthesize),
+        patch("tempfile.mkdtemp", side_effect=patched_mkdtemp),
+    ):
+        result = await voice_sender.send_voice_reply("Hello world", update)
+
+    assert result is True
+    reply_voice.assert_awaited_once()
+
+    # All temp dirs created should be gone after the call
+    for d in captured_tmp_dirs:
+        assert not Path(d).exists(), f"Temp dir {d} was not cleaned up"
+
+
+# ---------------------------------------------------------------------------
+# send_voice_reply — failure path: returns False and no file leak (4.6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reply_failure_returns_false(voice_sender, tmp_path):
+    """send_voice_reply returns False when synthesis raises, with no file leak."""
+    update = _make_update()
+
+    async def fail_synthesize(text: str, td: Path) -> Path:
+        raise RuntimeError("edge-tts not found")
+
+    captured_tmp_dirs: list = []
+    original_mkdtemp = __import__("tempfile").mkdtemp
+
+    def patched_mkdtemp(**kwargs):  # type: ignore[return]
+        d = original_mkdtemp(**kwargs)
+        captured_tmp_dirs.append(d)
+        return d
+
+    with (
+        patch.object(voice_sender, "_synthesize_ogg", side_effect=fail_synthesize),
+        patch("tempfile.mkdtemp", side_effect=patched_mkdtemp),
+    ):
+        result = await voice_sender.send_voice_reply("Hello", update)
+
+    assert result is False
+    # Temp dirs must still be cleaned up even on failure
+    for d in captured_tmp_dirs:
+        assert not Path(d).exists(), f"Temp dir {d} leaked on failure"

--- a/tests/unit/test_api/test_github_issues.py
+++ b/tests/unit/test_api/test_github_issues.py
@@ -1,0 +1,508 @@
+"""Unit tests for the GitHub issues webhook filter and helpers.
+
+Tests cover:
+- IssueWebhookFilter.should_trigger() — all filtering combinations
+- Payload helpers (_get_issue_labels, _get_labeled_label, etc.)
+- build_trigger_notification() output shape
+- _maybe_trigger_issue_sdd() integration with the event bus (via server)
+"""
+
+import hashlib
+import hmac
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.github_issues import (
+    IssueWebhookFilter,
+    _get_issue_labels,
+    _get_issue_number,
+    _get_issue_url,
+    _get_labeled_label,
+    _get_repo_full_name,
+    build_trigger_notification,
+)
+from src.api.server import create_api_app
+from src.events.bus import EventBus
+from src.events.types import AgentResponseEvent, ScheduledEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_issue_payload(
+    action: str = "opened",
+    labels: List[str] | None = None,
+    repo: str = "owner/repo",
+    issue_number: int = 7,
+    title: str = "Fix bug in login",
+    added_label: str | None = None,
+    issue_url: str = "https://github.com/owner/repo/issues/7",
+) -> Dict[str, Any]:
+    """Build a minimal GitHub ``issues`` webhook payload."""
+    label_objects = [{"name": lbl, "color": "abc"} for lbl in (labels or [])]
+    payload: Dict[str, Any] = {
+        "action": action,
+        "issue": {
+            "number": issue_number,
+            "title": title,
+            "body": "Detailed description",
+            "html_url": issue_url,
+            "labels": label_objects,
+        },
+        "repository": {
+            "full_name": repo,
+            "name": repo.split("/")[-1],
+        },
+    }
+    if added_label is not None:
+        payload["label"] = {"name": added_label, "color": "abc"}
+    return payload
+
+
+def _make_settings(**overrides: Any) -> MagicMock:
+    settings = MagicMock()
+    settings.development_mode = True
+    settings.github_webhook_secret = overrides.get("github_webhook_secret", "gh-secret")
+    settings.webhook_api_secret = overrides.get("webhook_api_secret", "api-secret")
+    settings.api_server_port = 8080
+    settings.debug = False
+    settings.enable_issue_webhook = overrides.get("enable_issue_webhook", True)
+    settings.issue_webhook_require_label = overrides.get(
+        "issue_webhook_require_label", True
+    )
+    settings.issue_webhook_label = overrides.get("issue_webhook_label", "sdd-analyze")
+    settings.issue_webhook_repo_allowlist = overrides.get(
+        "issue_webhook_repo_allowlist", []
+    )
+    settings.sdd_protected_branches = overrides.get(
+        "sdd_protected_branches", ["main", "master"]
+    )
+    settings.notification_chat_ids = overrides.get("notification_chat_ids", [123])
+    settings.approved_directory = Path("/tmp")
+    return settings
+
+
+def _sign(payload: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Payload helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadHelpers:
+    def test_get_issue_labels_returns_names(self) -> None:
+        payload = _make_issue_payload(labels=["sdd-analyze", "bug"])
+        assert _get_issue_labels(payload) == ["sdd-analyze", "bug"]
+
+    def test_get_issue_labels_empty(self) -> None:
+        payload = _make_issue_payload(labels=[])
+        assert _get_issue_labels(payload) == []
+
+    def test_get_issue_labels_missing_key(self) -> None:
+        assert _get_issue_labels({}) == []
+
+    def test_get_labeled_label_present(self) -> None:
+        payload = _make_issue_payload(action="labeled", added_label="sdd-analyze")
+        assert _get_labeled_label(payload) == "sdd-analyze"
+
+    def test_get_labeled_label_absent(self) -> None:
+        payload = _make_issue_payload(action="opened")
+        assert _get_labeled_label(payload) is None
+
+    def test_get_repo_full_name(self) -> None:
+        payload = _make_issue_payload(repo="paul/my-project")
+        assert _get_repo_full_name(payload) == "paul/my-project"
+
+    def test_get_issue_url(self) -> None:
+        payload = _make_issue_payload(issue_url="https://github.com/a/b/issues/1")
+        assert _get_issue_url(payload) == "https://github.com/a/b/issues/1"
+
+    def test_get_issue_number(self) -> None:
+        payload = _make_issue_payload(issue_number=42)
+        assert _get_issue_number(payload) == 42
+
+
+# ---------------------------------------------------------------------------
+# IssueWebhookFilter tests
+# ---------------------------------------------------------------------------
+
+
+class TestIssueWebhookFilter:
+    """Tests for all filtering combinations."""
+
+    def _filter(self, **kwargs: Any) -> IssueWebhookFilter:
+        defaults = dict(
+            enabled=True,
+            require_label=True,
+            target_label="sdd-analyze",
+            repo_allowlist=[],
+        )
+        defaults.update(kwargs)
+        return IssueWebhookFilter(**defaults)  # type: ignore[arg-type]
+
+    # -- feature flag --
+
+    def test_disabled_never_triggers(self) -> None:
+        f = self._filter(enabled=False)
+        payload = _make_issue_payload(action="opened", labels=["sdd-analyze"])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+        assert "disabled" in reason
+
+    # -- event type --
+
+    def test_non_issues_event_rejected(self) -> None:
+        f = self._filter()
+        ok, reason = f.should_trigger("push", {"action": "opened"})
+        assert ok is False
+        assert "push" in reason
+
+    def test_pull_request_event_rejected(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload()
+        ok, reason = f.should_trigger("pull_request", payload)
+        assert ok is False
+
+    # -- action --
+
+    def test_closed_action_rejected(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload(action="closed", labels=["sdd-analyze"])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+        assert "closed" in reason
+
+    def test_reopened_action_rejected(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload(action="reopened", labels=["sdd-analyze"])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+
+    # -- opened + label --
+
+    def test_opened_with_correct_label_triggers(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload(action="opened", labels=["sdd-analyze"])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is True
+
+    def test_opened_without_label_rejected_when_required(self) -> None:
+        f = self._filter(require_label=True)
+        payload = _make_issue_payload(action="opened", labels=["bug"])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+        assert "label" in reason
+
+    def test_opened_no_labels_rejected_when_required(self) -> None:
+        f = self._filter(require_label=True)
+        payload = _make_issue_payload(action="opened", labels=[])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+
+    def test_opened_no_label_required_triggers(self) -> None:
+        f = self._filter(require_label=False)
+        payload = _make_issue_payload(action="opened", labels=[])
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is True
+
+    # -- labeled action --
+
+    def test_labeled_with_correct_label_triggers(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload(action="labeled", added_label="sdd-analyze")
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is True
+
+    def test_labeled_with_wrong_label_rejected(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload(action="labeled", added_label="enhancement")
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+        assert "enhancement" in reason
+
+    def test_labeled_no_label_in_payload_rejected(self) -> None:
+        f = self._filter()
+        payload = _make_issue_payload(action="labeled")  # no added_label key
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+
+    # -- repo allowlist --
+
+    def test_allowlist_empty_means_all_repos_allowed(self) -> None:
+        f = self._filter(repo_allowlist=[], require_label=False)
+        payload = _make_issue_payload(action="opened", repo="any/repo")
+        ok, _ = f.should_trigger("issues", payload)
+        assert ok is True
+
+    def test_allowlist_repo_in_list_triggers(self) -> None:
+        f = self._filter(
+            repo_allowlist=["owner/repo"], require_label=False
+        )
+        payload = _make_issue_payload(action="opened", repo="owner/repo")
+        ok, _ = f.should_trigger("issues", payload)
+        assert ok is True
+
+    def test_allowlist_repo_not_in_list_rejected(self) -> None:
+        f = self._filter(
+            repo_allowlist=["owner/repo"], require_label=False
+        )
+        payload = _make_issue_payload(action="opened", repo="other/project")
+        ok, reason = f.should_trigger("issues", payload)
+        assert ok is False
+        assert "allowlist" in reason
+
+    def test_allowlist_is_case_insensitive(self) -> None:
+        f = self._filter(repo_allowlist=["Owner/Repo"], require_label=False)
+        payload = _make_issue_payload(action="opened", repo="owner/repo")
+        ok, _ = f.should_trigger("issues", payload)
+        assert ok is True
+
+    # -- combined --
+
+    def test_opened_with_label_and_allowed_repo_triggers(self) -> None:
+        f = self._filter(
+            require_label=True,
+            target_label="sdd-analyze",
+            repo_allowlist=["owner/repo"],
+        )
+        payload = _make_issue_payload(
+            action="opened", labels=["sdd-analyze"], repo="owner/repo"
+        )
+        ok, _ = f.should_trigger("issues", payload)
+        assert ok is True
+
+    def test_opened_with_label_but_disallowed_repo_rejected(self) -> None:
+        f = self._filter(
+            require_label=True,
+            target_label="sdd-analyze",
+            repo_allowlist=["owner/allowed"],
+        )
+        payload = _make_issue_payload(
+            action="opened", labels=["sdd-analyze"], repo="owner/other"
+        )
+        ok, _ = f.should_trigger("issues", payload)
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# build_trigger_notification tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTriggerNotification:
+    def test_contains_issue_number(self) -> None:
+        payload = _make_issue_payload(issue_number=42)
+        text = build_trigger_notification(payload)
+        assert "#42" in text
+
+    def test_contains_repo_name(self) -> None:
+        payload = _make_issue_payload(repo="paul/my-app")
+        text = build_trigger_notification(payload)
+        assert "paul/my-app" in text
+
+    def test_contains_issue_title(self) -> None:
+        payload = _make_issue_payload(title="Fix the login page")
+        text = build_trigger_notification(payload)
+        assert "Fix the login page" in text
+
+    def test_contains_html_link_when_url_present(self) -> None:
+        payload = _make_issue_payload(
+            issue_url="https://github.com/a/b/issues/5"
+        )
+        text = build_trigger_notification(payload)
+        assert "https://github.com/a/b/issues/5" in text
+
+    def test_no_link_when_url_absent(self) -> None:
+        payload = _make_issue_payload(issue_url="")
+        payload["issue"]["html_url"] = ""
+        text = build_trigger_notification(payload)
+        assert "<a href=" not in text
+
+
+# ---------------------------------------------------------------------------
+# Server integration — events published on matching issue webhook
+#
+# NOTE: EventBus.publish() enqueues into an asyncio.Queue — handlers are
+# only called when the bus processor loop is running.  FastAPI TestClient
+# runs a synchronous ASGI transport, so the queue is never drained during
+# the request.  We therefore mock event_bus.publish with an AsyncMock so
+# we can inspect every call without needing the bus loop.
+# ---------------------------------------------------------------------------
+
+
+class TestServerIssueWebhookIntegration:
+    """Verify that the server publishes the right events for issue webhooks."""
+
+    def _post_issue_webhook(
+        self,
+        client: TestClient,
+        payload: Dict[str, Any],
+        secret: str = "gh-secret",
+        event_type: str = "issues",
+        delivery_id: str = "delivery-001",
+    ) -> Any:
+        import json
+
+        body = json.dumps(payload).encode()
+        sig = _sign(body, secret)
+        return client.post(
+            "/webhooks/github",
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": event_type,
+                "X-GitHub-Delivery": delivery_id,
+            },
+        )
+
+    def _make_bus_with_mock_publish(self) -> tuple[EventBus, AsyncMock]:
+        """Return a bus whose publish() is replaced with an AsyncMock."""
+        bus = EventBus()
+        mock_publish = AsyncMock()
+        bus.publish = mock_publish  # type: ignore[method-assign]
+        return bus, mock_publish
+
+    def _published_types(self, mock_publish: AsyncMock) -> set[str]:
+        return {type(call.args[0]).__name__ for call in mock_publish.call_args_list}
+
+    def test_issue_opened_with_label_publishes_scheduled_event(self) -> None:
+        """Matching issue triggers notification + ScheduledEvent on bus."""
+        bus, mock_pub = self._make_bus_with_mock_publish()
+        settings = _make_settings(enable_issue_webhook=True)
+
+        app = create_api_app(
+            bus,
+            settings,
+            working_directory=Path("/tmp"),
+            notification_chat_ids=[456],
+        )
+        client = TestClient(app)
+
+        payload = _make_issue_payload(action="opened", labels=["sdd-analyze"])
+        resp = self._post_issue_webhook(client, payload)
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+
+        # We expect 3 publish calls: WebhookEvent + AgentResponseEvent + ScheduledEvent
+        published = self._published_types(mock_pub)
+        assert "WebhookEvent" in published
+        assert "ScheduledEvent" in published
+        assert "AgentResponseEvent" in published
+
+    def test_issue_opened_without_label_does_not_trigger_sdd(self) -> None:
+        """Issue without required label only publishes WebhookEvent."""
+        bus, mock_pub = self._make_bus_with_mock_publish()
+        settings = _make_settings(
+            enable_issue_webhook=True, issue_webhook_require_label=True
+        )
+
+        app = create_api_app(bus, settings, working_directory=Path("/tmp"))
+        client = TestClient(app)
+
+        payload = _make_issue_payload(action="opened", labels=["bug"])
+        resp = self._post_issue_webhook(
+            client, payload, delivery_id="delivery-no-label"
+        )
+
+        assert resp.status_code == 200
+        published = self._published_types(mock_pub)
+        assert "WebhookEvent" in published
+        assert "ScheduledEvent" not in published
+        assert "AgentResponseEvent" not in published
+
+    def test_issue_webhook_disabled_does_not_trigger_sdd(self) -> None:
+        """Feature flag off: no ScheduledEvent published even for matching issue."""
+        bus, mock_pub = self._make_bus_with_mock_publish()
+        settings = _make_settings(enable_issue_webhook=False)
+
+        app = create_api_app(bus, settings, working_directory=Path("/tmp"))
+        client = TestClient(app)
+
+        payload = _make_issue_payload(action="opened", labels=["sdd-analyze"])
+        resp = self._post_issue_webhook(
+            client, payload, delivery_id="delivery-disabled"
+        )
+
+        assert resp.status_code == 200
+        published = self._published_types(mock_pub)
+        assert "ScheduledEvent" not in published
+
+    def test_labeled_action_triggers_sdd(self) -> None:
+        """Issue labeled with the target label after creation also triggers SDD."""
+        bus, mock_pub = self._make_bus_with_mock_publish()
+        settings = _make_settings(enable_issue_webhook=True)
+
+        app = create_api_app(bus, settings, working_directory=Path("/tmp"))
+        client = TestClient(app)
+
+        payload = _make_issue_payload(action="labeled", added_label="sdd-analyze")
+        resp = self._post_issue_webhook(
+            client, payload, delivery_id="delivery-labeled"
+        )
+
+        assert resp.status_code == 200
+        published = self._published_types(mock_pub)
+        assert "ScheduledEvent" in published
+
+    def test_push_event_does_not_trigger_sdd(self) -> None:
+        """Non-issues events pass through without triggering SDD."""
+        bus, mock_pub = self._make_bus_with_mock_publish()
+        settings = _make_settings(enable_issue_webhook=True)
+
+        app = create_api_app(bus, settings, working_directory=Path("/tmp"))
+        client = TestClient(app)
+
+        import json
+
+        body = json.dumps({"ref": "refs/heads/main"}).encode()
+        sig = _sign(body, "gh-secret")
+        resp = client.post(
+            "/webhooks/github",
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": "push",
+                "X-GitHub-Delivery": "delivery-push",
+            },
+        )
+
+        assert resp.status_code == 200
+        published = self._published_types(mock_pub)
+        assert "ScheduledEvent" not in published
+
+    def test_no_notification_when_no_chat_ids(self) -> None:
+        """No AgentResponseEvent published when chat IDs are not configured."""
+        bus, mock_pub = self._make_bus_with_mock_publish()
+        settings = _make_settings(
+            enable_issue_webhook=True, notification_chat_ids=[]
+        )
+
+        app = create_api_app(
+            bus,
+            settings,
+            working_directory=Path("/tmp"),
+            notification_chat_ids=[],
+        )
+        client = TestClient(app)
+
+        payload = _make_issue_payload(action="opened", labels=["sdd-analyze"])
+        resp = self._post_issue_webhook(
+            client, payload, delivery_id="delivery-no-chats"
+        )
+
+        assert resp.status_code == 200
+        published = self._published_types(mock_pub)
+        # ScheduledEvent still published (Claude still runs), but no notification
+        assert "ScheduledEvent" in published
+        assert "AgentResponseEvent" not in published

--- a/tests/unit/test_bot/test_model_command.py
+++ b/tests/unit/test_bot/test_model_command.py
@@ -1,0 +1,242 @@
+"""Tests for the /model command — runtime model and effort switching.
+
+Covers:
+- /model shows inline keyboard with model choices
+- Model selection sets model_override and force_new_session
+- Effort selection sets effort_override
+- "default" clears all overrides
+- Haiku skips effort keyboard (not supported)
+- Opus shows "max" effort, Sonnet does not
+- _current_model_label returns correct labels
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram import InlineKeyboardMarkup
+
+from src.bot.handlers.command import (
+    _EFFORT_BY_MODEL,
+    _MODELS,
+    _current_model_label,
+    _handle_model_selection,
+    model_command,
+)
+from src.config.settings import Settings
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def settings(tmp_path):
+    return Settings(
+        telegram_bot_token="test:token",
+        telegram_bot_username="testbot",
+        approved_directory=tmp_path,
+    )
+
+
+@pytest.fixture
+def context(settings):
+    ctx = MagicMock()
+    ctx.user_data = {}
+    ctx.bot_data = {"settings": settings}
+    ctx.args = None
+    return ctx
+
+
+@pytest.fixture
+def update(context):
+    upd = MagicMock()
+    upd.message = AsyncMock()
+    upd.effective_user.id = 12345
+    return upd
+
+
+@pytest.fixture
+def callback_query():
+    query = MagicMock()
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    query.from_user.id = 12345
+    return query
+
+
+# ---------------------------------------------------------------------------
+# /model command (keyboard display)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_model_command_shows_keyboard(update, context):
+    """Verify /model sends an inline keyboard with model choices."""
+    await model_command(update, context)
+
+    update.message.reply_text.assert_called_once()
+    call_kwargs = update.message.reply_text.call_args
+    assert isinstance(call_kwargs.kwargs["reply_markup"], InlineKeyboardMarkup)
+    # Should contain the session warning
+    assert "new session" in call_kwargs.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_model_command_shows_current_override(update, context):
+    """When an override is active, /model should show it."""
+    context.user_data["model_override"] = _MODELS["sonnet"]
+    await model_command(update, context)
+
+    text = update.message.reply_text.call_args.args[0]
+    assert "Sonnet" in text
+
+
+# ---------------------------------------------------------------------------
+# Model selection callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_opus_sets_override(callback_query, context):
+    """Selecting Opus sets model_override and force_new_session."""
+    await _handle_model_selection(callback_query, "model:opus", context)
+
+    assert context.user_data["model_override"] == _MODELS["opus"]
+    assert context.user_data["force_new_session"] is True
+
+
+@pytest.mark.asyncio
+async def test_select_sonnet_sets_override(callback_query, context):
+    """Selecting Sonnet sets the correct model ID."""
+    await _handle_model_selection(callback_query, "model:sonnet", context)
+
+    assert context.user_data["model_override"] == _MODELS["sonnet"]
+
+
+@pytest.mark.asyncio
+async def test_select_haiku_skips_effort(callback_query, context):
+    """Selecting Haiku should not show effort keyboard (not supported)."""
+    await _handle_model_selection(callback_query, "model:haiku", context)
+
+    assert context.user_data["model_override"] == _MODELS["haiku"]
+    # Final message, no reply_markup (no effort keyboard)
+    call_kwargs = callback_query.edit_message_text.call_args
+    assert "reply_markup" not in call_kwargs.kwargs or call_kwargs.kwargs.get("reply_markup") is None
+    assert "ready" in call_kwargs.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_select_opus_shows_effort_with_max(callback_query, context):
+    """Opus should show effort keyboard including 'max'."""
+    await _handle_model_selection(callback_query, "model:opus", context)
+
+    call_kwargs = callback_query.edit_message_text.call_args
+    markup = call_kwargs.kwargs.get("reply_markup")
+    assert markup is not None
+    # Flatten button labels
+    labels = [btn.text for row in markup.inline_keyboard for btn in row]
+    assert "Max" in labels
+    assert "effort" in call_kwargs.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_select_sonnet_shows_effort_without_max(callback_query, context):
+    """Sonnet should show effort keyboard without 'max'."""
+    await _handle_model_selection(callback_query, "model:sonnet", context)
+
+    call_kwargs = callback_query.edit_message_text.call_args
+    markup = call_kwargs.kwargs.get("reply_markup")
+    assert markup is not None
+    labels = [btn.text for row in markup.inline_keyboard for btn in row]
+    assert "Max" not in labels
+    assert "High" in labels
+
+
+@pytest.mark.asyncio
+async def test_default_clears_overrides(callback_query, context):
+    """Selecting 'default' clears model, effort, and forces new session."""
+    context.user_data["model_override"] = _MODELS["opus"]
+    context.user_data["effort_override"] = "high"
+
+    await _handle_model_selection(callback_query, "model:default", context)
+
+    assert "model_override" not in context.user_data
+    assert "effort_override" not in context.user_data
+    assert context.user_data["force_new_session"] is True
+
+
+# ---------------------------------------------------------------------------
+# Effort selection callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_effort_sets_override(callback_query, context):
+    """Selecting an effort level stores it in user_data."""
+    context.user_data["model_override"] = _MODELS["opus"]
+
+    await _handle_model_selection(callback_query, "effort:high", context)
+
+    assert context.user_data["effort_override"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_effort_skip_keeps_existing(callback_query, context):
+    """Selecting 'skip' should not set effort_override."""
+    context.user_data["model_override"] = _MODELS["sonnet"]
+
+    await _handle_model_selection(callback_query, "effort:skip", context)
+
+    assert "effort_override" not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_model_switch_clears_stale_effort(callback_query, context):
+    """Switching models should clear any previous effort override."""
+    context.user_data["effort_override"] = "high"
+
+    await _handle_model_selection(callback_query, "model:haiku", context)
+
+    assert "effort_override" not in context.user_data
+
+
+# ---------------------------------------------------------------------------
+# Label helper
+# ---------------------------------------------------------------------------
+
+
+def test_label_default():
+    ctx = MagicMock()
+    ctx.user_data = {}
+    assert _current_model_label(ctx) == "Default"
+
+
+def test_label_with_model_and_effort():
+    ctx = MagicMock()
+    ctx.user_data = {"model_override": _MODELS["sonnet"], "effort_override": "medium"}
+    assert _current_model_label(ctx) == "Sonnet | effort=medium"
+
+
+def test_label_model_only():
+    ctx = MagicMock()
+    ctx.user_data = {"model_override": _MODELS["opus"]}
+    assert _current_model_label(ctx) == "Opus"
+
+
+# ---------------------------------------------------------------------------
+# Effort level configuration
+# ---------------------------------------------------------------------------
+
+
+def test_haiku_has_no_effort_levels():
+    assert _EFFORT_BY_MODEL["haiku"] == []
+
+
+def test_sonnet_has_no_max():
+    assert "max" not in _EFFORT_BY_MODEL["sonnet"]
+    assert "high" in _EFFORT_BY_MODEL["sonnet"]
+
+
+def test_opus_has_max():
+    assert "max" in _EFFORT_BY_MODEL["opus"]

--- a/tests/unit/test_bot/test_model_command.py
+++ b/tests/unit/test_bot/test_model_command.py
@@ -8,6 +8,8 @@ Covers:
 - Haiku skips effort keyboard (not supported)
 - Opus shows "max" effort, Sonnet does not
 - _current_model_label returns correct labels
+- Regression: model: callback data prefix is never rewritten as effort:
+- force_new_session is always set on model change
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -17,7 +19,7 @@ from telegram import InlineKeyboardMarkup
 
 from src.bot.handlers.command import (
     _EFFORT_BY_MODEL,
-    _MODELS,
+    _MODEL_FAMILIES,
     _current_model_label,
     _handle_model_selection,
     model_command,
@@ -85,7 +87,7 @@ async def test_model_command_shows_keyboard(update, context):
 @pytest.mark.asyncio
 async def test_model_command_shows_current_override(update, context):
     """When an override is active, /model should show it."""
-    context.user_data["model_override"] = _MODELS["sonnet"]
+    context.user_data["model_override"] = "sonnet"
     await model_command(update, context)
 
     text = update.message.reply_text.call_args.args[0]
@@ -99,19 +101,19 @@ async def test_model_command_shows_current_override(update, context):
 
 @pytest.mark.asyncio
 async def test_select_opus_sets_override(callback_query, context):
-    """Selecting Opus sets model_override and force_new_session."""
+    """Selecting Opus sets model_override to short alias and force_new_session."""
     await _handle_model_selection(callback_query, "model:opus", context)
 
-    assert context.user_data["model_override"] == _MODELS["opus"]
+    assert context.user_data["model_override"] == "opus"
     assert context.user_data["force_new_session"] is True
 
 
 @pytest.mark.asyncio
 async def test_select_sonnet_sets_override(callback_query, context):
-    """Selecting Sonnet sets the correct model ID."""
+    """Selecting Sonnet sets the correct short alias."""
     await _handle_model_selection(callback_query, "model:sonnet", context)
 
-    assert context.user_data["model_override"] == _MODELS["sonnet"]
+    assert context.user_data["model_override"] == "sonnet"
 
 
 @pytest.mark.asyncio
@@ -119,7 +121,7 @@ async def test_select_haiku_skips_effort(callback_query, context):
     """Selecting Haiku should not show effort keyboard (not supported)."""
     await _handle_model_selection(callback_query, "model:haiku", context)
 
-    assert context.user_data["model_override"] == _MODELS["haiku"]
+    assert context.user_data["model_override"] == "haiku"
     # Final message, no reply_markup (no effort keyboard)
     call_kwargs = callback_query.edit_message_text.call_args
     assert "reply_markup" not in call_kwargs.kwargs or call_kwargs.kwargs.get("reply_markup") is None
@@ -156,7 +158,7 @@ async def test_select_sonnet_shows_effort_without_max(callback_query, context):
 @pytest.mark.asyncio
 async def test_default_clears_overrides(callback_query, context):
     """Selecting 'default' clears model, effort, and forces new session."""
-    context.user_data["model_override"] = _MODELS["opus"]
+    context.user_data["model_override"] = "opus"
     context.user_data["effort_override"] = "high"
 
     await _handle_model_selection(callback_query, "model:default", context)
@@ -174,7 +176,7 @@ async def test_default_clears_overrides(callback_query, context):
 @pytest.mark.asyncio
 async def test_effort_sets_override(callback_query, context):
     """Selecting an effort level stores it in user_data."""
-    context.user_data["model_override"] = _MODELS["opus"]
+    context.user_data["model_override"] = "opus"
 
     await _handle_model_selection(callback_query, "effort:high", context)
 
@@ -184,7 +186,7 @@ async def test_effort_sets_override(callback_query, context):
 @pytest.mark.asyncio
 async def test_effort_skip_keeps_existing(callback_query, context):
     """Selecting 'skip' should not set effort_override."""
-    context.user_data["model_override"] = _MODELS["sonnet"]
+    context.user_data["model_override"] = "sonnet"
 
     await _handle_model_selection(callback_query, "effort:skip", context)
 
@@ -199,6 +201,44 @@ async def test_model_switch_clears_stale_effort(callback_query, context):
     await _handle_model_selection(callback_query, "model:haiku", context)
 
     assert "effort_override" not in context.user_data
+
+
+# ---------------------------------------------------------------------------
+# Regression: callback data prefix integrity (closure-bug guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_model_callback_sets_model_not_effort(callback_query, context):
+    """model: callback must set model_override, not effort_override.
+
+    Regression guard: a shared closure capturing 'action' from outer scope
+    could silently rewrite 'model:opus' as 'effort:opus'. This test would
+    have caught that.
+    """
+    await _handle_model_selection(callback_query, "model:sonnet", context)
+
+    assert context.user_data.get("model_override") == "sonnet"
+    assert "effort_override" not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_effort_callback_sets_effort_not_model(callback_query, context):
+    """effort: callback must set effort_override and not overwrite model_override."""
+    context.user_data["model_override"] = "sonnet"
+
+    await _handle_model_selection(callback_query, "effort:high", context)
+
+    assert context.user_data.get("effort_override") == "high"
+    assert context.user_data.get("model_override") == "sonnet"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_force_new_session_set_on_model_switch(callback_query, context):
+    """force_new_session must be True after any model switch."""
+    await _handle_model_selection(callback_query, "model:opus", context)
+
+    assert context.user_data.get("force_new_session") is True
 
 
 # ---------------------------------------------------------------------------
@@ -222,13 +262,13 @@ def test_label_default_with_server_model():
 
 def test_label_with_model_and_effort():
     ctx = MagicMock()
-    ctx.user_data = {"model_override": _MODELS["sonnet"], "effort_override": "medium"}
+    ctx.user_data = {"model_override": "sonnet", "effort_override": "medium"}
     assert _current_model_label(ctx) == "Sonnet | effort=medium"
 
 
 def test_label_model_only():
     ctx = MagicMock()
-    ctx.user_data = {"model_override": _MODELS["opus"]}
+    ctx.user_data = {"model_override": "opus"}
     assert _current_model_label(ctx) == "Opus"
 
 
@@ -248,3 +288,9 @@ def test_sonnet_has_no_max():
 
 def test_opus_has_max():
     assert "max" in _EFFORT_BY_MODEL["opus"]
+
+
+def test_model_families_contains_expected():
+    assert "opus" in _MODEL_FAMILIES
+    assert "sonnet" in _MODEL_FAMILIES
+    assert "haiku" in _MODEL_FAMILIES

--- a/tests/unit/test_bot/test_model_command.py
+++ b/tests/unit/test_bot/test_model_command.py
@@ -206,10 +206,18 @@ async def test_model_switch_clears_stale_effort(callback_query, context):
 # ---------------------------------------------------------------------------
 
 
-def test_label_default():
+def test_label_default_no_settings():
     ctx = MagicMock()
     ctx.user_data = {}
-    assert _current_model_label(ctx) == "Default"
+    ctx.bot_data = {}
+    assert _current_model_label(ctx) == "Default (CLI default)"
+
+
+def test_label_default_with_server_model():
+    ctx = MagicMock()
+    ctx.user_data = {}
+    ctx.bot_data = {"settings": MagicMock(claude_model="claude-sonnet-4-6")}
+    assert _current_model_label(ctx) == "Default (claude-sonnet-4-6)"
 
 
 def test_label_with_model_and_effort():

--- a/tests/unit/test_claude/test_monitor.py
+++ b/tests/unit/test_claude/test_monitor.py
@@ -1,4 +1,4 @@
-"""Test bash directory boundary checking."""
+"""Test bash directory boundary checking and git safety."""
 
 from pathlib import Path
 from unittest.mock import patch
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from src.claude.monitor import (
     _is_claude_internal_path,
     check_bash_directory_boundary,
+    check_git_safety,
 )
 
 
@@ -287,3 +288,135 @@ class TestIsClaudeInternalPath:
             bad_file = tmp_path / ".claude" / "secrets" / "key.pem"
             bad_file.touch()
             assert _is_claude_internal_path(str(bad_file)) is False
+
+
+class TestCheckGitSafety:
+    """Tests for the check_git_safety function."""
+
+    _PROTECTED = ["main", "develop", "master"]
+
+    # ── Non-git commands pass through ─────────────────────────────────────────
+
+    def test_non_git_command_passes(self) -> None:
+        ok, err = check_git_safety("ls -la", self._PROTECTED, False, False)
+        assert ok is True
+        assert err is None
+
+    def test_python_command_passes(self) -> None:
+        ok, err = check_git_safety("python script.py", self._PROTECTED, False, False)
+        assert ok is True
+        assert err is None
+
+    # ── Push to protected branch ──────────────────────────────────────────────
+
+    def test_push_to_main_is_blocked(self) -> None:
+        ok, err = check_git_safety(
+            "git push origin main", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert err is not None
+        assert "main" in err
+
+    def test_push_to_develop_is_blocked(self) -> None:
+        ok, err = check_git_safety(
+            "git push origin develop", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert "develop" in err
+
+    def test_push_to_feature_branch_is_allowed(self) -> None:
+        ok, err = check_git_safety(
+            "git push origin feature/my-feature", self._PROTECTED, False, False
+        )
+        assert ok is True
+        assert err is None
+
+    def test_push_to_branch_containing_main_as_substring_is_allowed(self) -> None:
+        """'my-main-fix' must NOT be blocked when 'main' is protected."""
+        ok, err = check_git_safety(
+            "git push origin my-main-fix", self._PROTECTED, False, False
+        )
+        assert ok is True
+        assert err is None
+
+    def test_push_to_branch_with_remote_upstream_is_blocked(self) -> None:
+        ok, err = check_git_safety(
+            "git push upstream main", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert err is not None
+
+    # ── Force push ────────────────────────────────────────────────────────────
+
+    def test_force_push_blocked_by_default(self) -> None:
+        ok, err = check_git_safety(
+            "git push --force origin feature/x", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert err is not None
+
+    def test_force_push_short_flag_blocked(self) -> None:
+        ok, err = check_git_safety("git push -f", self._PROTECTED, False, False)
+        assert ok is False
+        assert err is not None
+
+    def test_force_push_allowed_when_enabled(self) -> None:
+        ok, err = check_git_safety(
+            "git push --force origin feature/x", self._PROTECTED, True, False
+        )
+        assert ok is True
+        assert err is None
+
+    # ── Branch force delete ───────────────────────────────────────────────────
+
+    def test_branch_force_delete_blocked_by_default(self) -> None:
+        ok, err = check_git_safety(
+            "git branch -D feature/old", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert err is not None
+
+    def test_branch_soft_delete_always_allowed(self) -> None:
+        ok, err = check_git_safety(
+            "git branch -d feature/old", self._PROTECTED, False, False
+        )
+        assert ok is True
+        assert err is None
+
+    def test_branch_force_delete_allowed_when_enabled(self) -> None:
+        ok, err = check_git_safety(
+            "git branch -D feature/old", self._PROTECTED, False, True
+        )
+        assert ok is True
+        assert err is None
+
+    # ── Hard reset ────────────────────────────────────────────────────────────
+
+    def test_reset_hard_to_protected_ref_blocked(self) -> None:
+        ok, err = check_git_safety(
+            "git reset --hard origin/main", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert err is not None
+        assert "origin/main" in err
+
+    def test_reset_hard_to_non_protected_ref_allowed(self) -> None:
+        ok, err = check_git_safety(
+            "git reset --hard HEAD~1", self._PROTECTED, False, False
+        )
+        assert ok is True
+        assert err is None
+
+    def test_reset_hard_to_protected_branch_by_name_blocked(self) -> None:
+        ok, err = check_git_safety(
+            "git reset --hard main", self._PROTECTED, False, False
+        )
+        assert ok is False
+        assert err is not None
+
+    # ── Empty protected branches list ─────────────────────────────────────────
+
+    def test_push_with_empty_protected_branches_allowed(self) -> None:
+        ok, err = check_git_safety("git push origin main", [], False, False)
+        assert ok is True
+        assert err is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -698,3 +698,67 @@ def test_configuration_error_handling():
                 "APPROVED_DIRECTORY",
             ]:
                 os.environ.pop(key, None)
+
+
+class TestGitSafetySettings:
+    """Test git safety settings defaults and parsing."""
+
+    def test_git_protected_branches_defaults(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+        )
+        assert settings.git_protected_branches == ["main", "develop", "master"]
+
+    def test_git_allow_force_push_defaults_false(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+        )
+        assert settings.git_allow_force_push is False
+
+    def test_git_allow_delete_branch_defaults_false(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+        )
+        assert settings.git_allow_delete_branch is False
+
+    def test_git_protected_branches_comma_string_parsing(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+            git_protected_branches="main, release, staging",
+        )
+        assert settings.git_protected_branches == ["main", "release", "staging"]
+
+    def test_git_protected_branches_list_passthrough(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+            git_protected_branches=["main", "release"],
+        )
+        assert settings.git_protected_branches == ["main", "release"]
+
+    def test_git_allow_force_push_can_be_enabled(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+            git_allow_force_push=True,
+        )
+        assert settings.git_allow_force_push is True
+
+    def test_git_allow_delete_branch_can_be_enabled(self, tmp_path: Path) -> None:
+        settings = Settings(
+            telegram_bot_token="test_token",
+            telegram_bot_username="test_bot",
+            approved_directory=str(tmp_path),
+            git_allow_delete_branch=True,
+        )
+        assert settings.git_allow_delete_branch is True

--- a/tests/unit/test_events/test_concurrent_scheduled.py
+++ b/tests/unit/test_events/test_concurrent_scheduled.py
@@ -1,0 +1,124 @@
+"""Tests for concurrent scheduled event handling."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.events.bus import EventBus
+from src.events.handlers import AgentHandler
+from src.events.types import ScheduledEvent, WebhookEvent
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def mock_claude() -> AsyncMock:
+    mock = AsyncMock()
+    mock.run_command = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def agent_handler(event_bus: EventBus, mock_claude: AsyncMock) -> AgentHandler:
+    return AgentHandler(
+        event_bus=event_bus,
+        claude_integration=mock_claude,
+        default_working_directory=Path("/tmp/test"),
+        default_user_id=42,
+    )
+
+
+class TestConcurrentScheduledHandling:
+    """Tests for background dispatch of scheduled jobs."""
+
+    async def test_handle_scheduled_returns_immediately(
+        self, agent_handler: AgentHandler, mock_claude: AsyncMock
+    ) -> None:
+        """Scheduled jobs should dispatch to the background and return fast."""
+
+        async def slow_run_command(**_: object) -> MagicMock:
+            await asyncio.sleep(10)
+            response = MagicMock()
+            response.content = "done"
+            return response
+
+        mock_claude.run_command.side_effect = slow_run_command
+        event = ScheduledEvent(
+            job_name="standup",
+            prompt="Generate daily standup",
+            target_chat_ids=[100],
+        )
+
+        await asyncio.wait_for(agent_handler.handle_scheduled(event), timeout=1.0)
+
+        for task in list(getattr(agent_handler, "_background_tasks", set())):
+            task.cancel()
+        if getattr(agent_handler, "_background_tasks", None):
+            await asyncio.gather(*agent_handler._background_tasks, return_exceptions=True)
+
+    def test_scheduled_semaphore_limits_concurrency(
+        self, agent_handler: AgentHandler
+    ) -> None:
+        """Scheduled jobs are capped to two concurrent Claude executions."""
+        assert agent_handler._scheduled_semaphore._value == 2
+
+    async def test_scheduled_task_errors_are_logged_not_raised(
+        self, agent_handler: AgentHandler, mock_claude: AsyncMock
+    ) -> None:
+        """Background scheduled task failures should be logged, not propagated."""
+
+        async def boom(**_: object) -> MagicMock:
+            raise RuntimeError("SDK error")
+
+        mock_claude.run_command.side_effect = boom
+        event = ScheduledEvent(
+            job_name="standup",
+            prompt="Generate daily standup",
+            target_chat_ids=[100],
+        )
+
+        with patch("src.events.handlers.logger.exception") as mock_log:
+            await agent_handler.handle_scheduled(event)
+            tasks = list(agent_handler._background_tasks)
+            assert tasks
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.sleep(0)
+
+        mock_log.assert_called()
+
+    async def test_webhook_handler_still_blocks(
+        self, agent_handler: AgentHandler, mock_claude: AsyncMock
+    ) -> None:
+        """Webhook handling should still await Claude directly."""
+        release = asyncio.Event()
+        started = asyncio.Event()
+
+        async def blocked_run_command(**_: object) -> MagicMock:
+            started.set()
+            await release.wait()
+            response = MagicMock()
+            response.content = "done"
+            return response
+
+        mock_claude.run_command.side_effect = blocked_run_command
+        event = WebhookEvent(
+            provider="github",
+            event_type_name="push",
+            payload={"ref": "refs/heads/main"},
+            delivery_id="del-1",
+        )
+
+        task = asyncio.create_task(agent_handler.handle_webhook(event))
+        await started.wait()
+        await asyncio.sleep(0)
+
+        assert not task.done()
+
+        release.set()
+        await asyncio.wait_for(task, timeout=1.0)
+        mock_claude.run_command.assert_awaited_once()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -82,8 +82,8 @@ def deps():
     }
 
 
-def test_agentic_registers_6_commands(agentic_settings, deps):
-    """Agentic mode registers start, new, status, verbose, repo, restart commands."""
+def test_agentic_registers_7_commands(agentic_settings, deps):
+    """Agentic mode registers start, new, status, verbose, repo, model, restart commands."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     app = MagicMock()
     app.add_handler = MagicMock()
@@ -100,17 +100,18 @@ def test_agentic_registers_6_commands(agentic_settings, deps):
     ]
     commands = [h[0][0].commands for h in cmd_handlers]
 
-    assert len(cmd_handlers) == 6
+    assert len(cmd_handlers) == 7
     assert frozenset({"start"}) in commands
     assert frozenset({"new"}) in commands
     assert frozenset({"status"}) in commands
     assert frozenset({"verbose"}) in commands
     assert frozenset({"repo"}) in commands
+    assert frozenset({"model"}) in commands
     assert frozenset({"restart"}) in commands
 
 
-def test_classic_registers_14_commands(classic_settings, deps):
-    """Classic mode registers all 14 commands."""
+def test_classic_registers_15_commands(classic_settings, deps):
+    """Classic mode registers all 15 commands."""
     orchestrator = MessageOrchestrator(classic_settings, deps)
     app = MagicMock()
     app.add_handler = MagicMock()
@@ -125,7 +126,7 @@ def test_classic_registers_14_commands(classic_settings, deps):
         if isinstance(call[0][0], CommandHandler)
     ]
 
-    assert len(cmd_handlers) == 14
+    assert len(cmd_handlers) == 15
 
 
 def test_agentic_registers_text_document_photo_handlers(agentic_settings, deps):
@@ -151,30 +152,31 @@ def test_agentic_registers_text_document_photo_handlers(agentic_settings, deps):
 
     # 5 message handlers (text, document, photo, voice, unknown commands passthrough)
     assert len(msg_handlers) == 5
-    # 2 callback handlers (stop: + cd:)
-    assert len(cb_handlers) == 2
+    # 3 callback handlers (stop: + model/effort: + cd:)
+    assert len(cb_handlers) == 3
 
 
 async def test_agentic_bot_commands(agentic_settings, deps):
-    """Agentic mode returns 6 bot commands."""
+    """Agentic mode returns 7 bot commands."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     commands = await orchestrator.get_bot_commands()
 
-    assert len(commands) == 6
+    assert len(commands) == 7
     cmd_names = [c.command for c in commands]
-    assert cmd_names == ["start", "new", "status", "verbose", "repo", "restart"]
+    assert cmd_names == ["start", "new", "status", "verbose", "repo", "model", "restart"]
 
 
 async def test_classic_bot_commands(classic_settings, deps):
-    """Classic mode returns 14 bot commands."""
+    """Classic mode returns 15 bot commands."""
     orchestrator = MessageOrchestrator(classic_settings, deps)
     commands = await orchestrator.get_bot_commands()
 
-    assert len(commands) == 14
+    assert len(commands) == 15
     cmd_names = [c.command for c in commands]
     assert "start" in cmd_names
     assert "help" in cmd_names
     assert "git" in cmd_names
+    assert "model" in cmd_names
     assert "restart" in cmd_names
 
 
@@ -338,7 +340,7 @@ async def test_agentic_callback_scoped_to_cd_pattern(agentic_settings, deps):
         if isinstance(call[0][0], CallbackQueryHandler)
     ]
 
-    assert len(cb_handlers) == 2
+    assert len(cb_handlers) == 3
     # Find the cd: handler by pattern
     cd_handler = [h for h in cb_handlers if h.pattern and h.pattern.match("cd:x")]
     assert len(cd_handler) == 1

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -82,8 +82,8 @@ def deps():
     }
 
 
-def test_agentic_registers_6_commands(agentic_settings, deps):
-    """Agentic mode registers start, new, status, verbose, repo, restart commands."""
+def test_agentic_registers_7_commands(agentic_settings, deps):
+    """Agentic mode registers start, new, status, verbose, repo, restart, sdd commands."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     app = MagicMock()
     app.add_handler = MagicMock()
@@ -100,13 +100,14 @@ def test_agentic_registers_6_commands(agentic_settings, deps):
     ]
     commands = [h[0][0].commands for h in cmd_handlers]
 
-    assert len(cmd_handlers) == 6
+    assert len(cmd_handlers) == 7
     assert frozenset({"start"}) in commands
     assert frozenset({"new"}) in commands
     assert frozenset({"status"}) in commands
     assert frozenset({"verbose"}) in commands
     assert frozenset({"repo"}) in commands
     assert frozenset({"restart"}) in commands
+    assert frozenset({"sdd"}) in commands
 
 
 def test_classic_registers_14_commands(classic_settings, deps):
@@ -156,13 +157,13 @@ def test_agentic_registers_text_document_photo_handlers(agentic_settings, deps):
 
 
 async def test_agentic_bot_commands(agentic_settings, deps):
-    """Agentic mode returns 6 bot commands."""
+    """Agentic mode returns 7 bot commands including /sdd."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     commands = await orchestrator.get_bot_commands()
 
-    assert len(commands) == 6
+    assert len(commands) == 7
     cmd_names = [c.command for c in commands]
-    assert cmd_names == ["start", "new", "status", "verbose", "repo", "restart"]
+    assert cmd_names == ["start", "new", "status", "verbose", "repo", "restart", "sdd"]
 
 
 async def test_classic_bot_commands(classic_settings, deps):

--- a/tests/unit/test_orchestrator_voice_command.py
+++ b/tests/unit/test_orchestrator_voice_command.py
@@ -1,0 +1,321 @@
+"""Tests for /voice command handling and _should_send_voice logic."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.bot.orchestrator import MessageOrchestrator
+from src.config.settings import Settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(tmp_dir: Path, **overrides) -> Settings:
+    """Build Settings directly, bypassing .env file to avoid test-env issues."""
+    defaults = dict(
+        telegram_bot_token="test_token_123",
+        telegram_bot_username="test_bot",
+        approved_directory=str(tmp_dir),
+        agentic_mode=True,
+        enable_voice_replies=True,
+        voice_reply_mode="manual",
+        voice_reply_max_words=200,
+        edge_tts_voice="es-AR-TomasNeural",
+    )
+    defaults.update(overrides)
+    return Settings(_env_file=None, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def voice_settings(tmp_dir):
+    """Settings with voice replies enabled."""
+    return _make_settings(tmp_dir)
+
+
+@pytest.fixture
+def no_voice_settings(tmp_dir):
+    """Settings with voice replies disabled."""
+    return _make_settings(tmp_dir, enable_voice_replies=False)
+
+
+@pytest.fixture
+def deps():
+    return {
+        "claude_integration": MagicMock(),
+        "storage": MagicMock(),
+        "security_validator": MagicMock(),
+        "rate_limiter": MagicMock(),
+        "audit_logger": MagicMock(),
+        "features": MagicMock(),
+    }
+
+
+def _make_context(user_data: dict | None = None, bot_data: dict | None = None):
+    """Build a minimal mock context."""
+    ctx = MagicMock()
+    ctx.user_data = user_data if user_data is not None else {}
+    ctx.bot_data = bot_data if bot_data is not None else {}
+    return ctx
+
+
+def _make_update(text: str) -> MagicMock:
+    """Build a minimal mock Update with message.text."""
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    update.effective_user = MagicMock()
+    update.effective_user.id = 12345
+    return update
+
+
+# ---------------------------------------------------------------------------
+# /voice on — sets user_data and sends confirmation (4.7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_on_sets_state(voice_settings, deps):
+    """/voice on sets user_data['voice_reply'] = 'on' and sends confirmation."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context()
+    update = _make_update("/voice on")
+
+    await orchestrator.agentic_voice_command(update, context)
+
+    assert context.user_data.get("voice_reply") == "on"
+    update.message.reply_text.assert_awaited_once()
+    reply_text = update.message.reply_text.call_args[0][0]
+    assert "enabled" in reply_text.lower() or "voice" in reply_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# /voice off and /voice auto — state transitions (4.8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_off_sets_state(voice_settings, deps):
+    """/voice off sets user_data['voice_reply'] = 'off'."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+    update = _make_update("/voice off")
+
+    await orchestrator.agentic_voice_command(update, context)
+
+    assert context.user_data.get("voice_reply") == "off"
+
+
+@pytest.mark.asyncio
+async def test_voice_auto_sets_state(voice_settings, deps):
+    """/voice auto sets user_data['voice_reply'] = 'auto'."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context()
+    update = _make_update("/voice auto")
+
+    await orchestrator.agentic_voice_command(update, context)
+
+    assert context.user_data.get("voice_reply") == "auto"
+
+
+# ---------------------------------------------------------------------------
+# /voice (no args) — returns current status (4.9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_no_args_shows_status(voice_settings, deps):
+    """/voice with no args replies with current status without changing state."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "auto"})
+    update = _make_update("/voice")
+
+    await orchestrator.agentic_voice_command(update, context)
+
+    # State unchanged
+    assert context.user_data.get("voice_reply") == "auto"
+    # Should have replied
+    update.message.reply_text.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# /voice xyz — invalid arg, state unchanged (4.9 edge)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_invalid_arg_does_not_change_state(voice_settings, deps):
+    """/voice xyz replies with usage info and does not change state."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "off"})
+    update = _make_update("/voice xyz")
+
+    await orchestrator.agentic_voice_command(update, context)
+
+    assert context.user_data.get("voice_reply") == "off"
+
+
+# ---------------------------------------------------------------------------
+# /voice disabled — feature flag check (4.7 edge)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_feature_disabled_informs_user(no_voice_settings, deps):
+    """/voice when feature is disabled informs the user."""
+    orchestrator = MessageOrchestrator(settings=no_voice_settings, deps=deps)
+    context = _make_context()
+    update = _make_update("/voice on")
+
+    await orchestrator.agentic_voice_command(update, context)
+
+    # State must NOT be set
+    assert "voice_reply" not in context.user_data
+    update.message.reply_text.assert_awaited_once()
+    reply_text = update.message.reply_text.call_args[0][0]
+    assert "disabled" in reply_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# _should_send_voice — auto mode (word-count gate) (4.10)
+# ---------------------------------------------------------------------------
+
+
+def test_should_send_voice_auto_short_text(voice_settings, deps):
+    """Auto mode returns True for response within word limit, no user intent needed."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "auto"})
+    short_text = " ".join(["word"] * 150)  # 150 words, limit = 200
+
+    assert orchestrator._should_send_voice(context, short_text) is True
+
+
+def test_should_send_voice_auto_long_text(voice_settings, deps):
+    """Auto mode returns False for response exceeding word limit."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "auto"})
+    long_text = " ".join(["word"] * 250)  # 250 words, limit = 200
+
+    assert orchestrator._should_send_voice(context, long_text) is False
+
+
+def test_should_send_voice_auto_ignores_user_intent(voice_settings, deps):
+    """Auto mode sends voice based only on word count, not user intent keywords."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "auto"})
+    short_text = " ".join(["word"] * 50)
+
+    # Even without voice keywords in user_message, auto triggers on word count
+    assert orchestrator._should_send_voice(context, short_text, user_message="hello") is True
+
+
+# ---------------------------------------------------------------------------
+# _should_send_voice — on mode (explicit intent required) (4.10)
+# ---------------------------------------------------------------------------
+
+
+def test_should_send_voice_on_with_explicit_voice_request_es(voice_settings, deps):
+    """'on' mode returns True when user explicitly asks for voice in Spanish."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+
+    assert orchestrator._should_send_voice(
+        context, "response text", user_message="respondeme en voz"
+    ) is True
+
+
+def test_should_send_voice_on_with_explicit_voice_request_en(voice_settings, deps):
+    """'on' mode returns True when user explicitly asks for voice in English."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+
+    assert orchestrator._should_send_voice(
+        context, "response text", user_message="send audio please"
+    ) is True
+
+
+def test_should_send_voice_on_without_voice_request(voice_settings, deps):
+    """'on' mode returns False when user message has no voice intent keywords."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+
+    assert orchestrator._should_send_voice(
+        context, "response text", user_message="what is the weather today?"
+    ) is False
+
+
+def test_should_send_voice_on_no_user_message(voice_settings, deps):
+    """'on' mode returns False when user_message is empty (no intent detectable)."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+
+    assert orchestrator._should_send_voice(context, "response text", user_message="") is False
+
+
+def test_should_send_voice_on_long_response_with_voice_request(voice_settings, deps):
+    """'on' mode returns True even for long responses as long as user asked for voice."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+    long_response = " ".join(["word"] * 1000)
+
+    assert orchestrator._should_send_voice(
+        context, long_response, user_message="mandame un audio"
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# _should_send_voice — off mode and feature flag (4.10)
+# ---------------------------------------------------------------------------
+
+
+def test_should_send_voice_off_returns_false(voice_settings, deps):
+    """'off' mode always returns False regardless of user message."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "off"})
+
+    assert orchestrator._should_send_voice(
+        context, "Hello", user_message="en voz por favor"
+    ) is False
+
+
+def test_should_send_voice_feature_disabled_returns_false(no_voice_settings, deps):
+    """Returns False when feature is disabled regardless of user_data or user_message."""
+    orchestrator = MessageOrchestrator(settings=no_voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+
+    assert orchestrator._should_send_voice(
+        context, "Hello", user_message="en voz"
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# agentic_new — resets voice_reply (4.11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agentic_new_clears_voice_reply(voice_settings, deps):
+    """/new clears voice_reply from user_data."""
+    orchestrator = MessageOrchestrator(settings=voice_settings, deps=deps)
+    context = _make_context(user_data={"voice_reply": "on"})
+    update = _make_update("/new")
+
+    await orchestrator.agentic_new(update, context)
+
+    assert "voice_reply" not in context.user_data

--- a/tests/unit/test_schedule_handler.py
+++ b/tests/unit/test_schedule_handler.py
@@ -1,0 +1,214 @@
+"""Tests for the /schedule command handler."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.bot.handlers.schedule import schedule_command
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def mock_scheduler():
+    scheduler = AsyncMock()
+    scheduler.list_jobs = AsyncMock(return_value=[])
+    scheduler.add_job = AsyncMock(return_value="job-123")
+    scheduler.remove_job = AsyncMock(return_value=True)
+    scheduler.pause_job = AsyncMock(return_value=True)
+    scheduler.resume_job = AsyncMock(return_value=True)
+    return scheduler
+
+
+@pytest.fixture
+def update():
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.reply_text = AsyncMock()
+    update.message.reply_html = AsyncMock()
+    update.effective_chat = MagicMock()
+    update.effective_chat.id = 12345
+    update.effective_user = MagicMock()
+    update.effective_user.id = 67890
+    return update
+
+
+@pytest.fixture
+def context(mock_scheduler, tmp_dir):
+    context = MagicMock()
+    context.bot_data = {
+        "scheduler": mock_scheduler,
+        "settings": MagicMock(approved_directory=tmp_dir),
+    }
+    context.user_data = {"current_directory": tmp_dir}
+    context.args = []
+    return context
+
+
+async def test_no_scheduler_shows_error(update, context):
+    """When scheduler is not injected, show error message."""
+    context.bot_data["scheduler"] = None
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "not enabled" in update.message.reply_text.call_args[0][0]
+
+
+async def test_no_args_shows_usage(update, context):
+    """No subcommand shows usage info."""
+    context.args = []
+    await schedule_command(update, context)
+    update.message.reply_html.assert_called_once()
+    assert "Usage" in update.message.reply_html.call_args[0][0]
+
+
+async def test_unknown_subcommand_shows_usage(update, context):
+    """Unknown subcommand shows usage info."""
+    context.args = ["unknown"]
+    await schedule_command(update, context)
+    update.message.reply_html.assert_called_once()
+    assert "Usage" in update.message.reply_html.call_args[0][0]
+
+
+async def test_list_empty(update, context, mock_scheduler):
+    """List with no jobs shows empty message."""
+    context.args = ["list"]
+    await schedule_command(update, context)
+    mock_scheduler.list_jobs.assert_called_once_with(include_paused=True)
+    update.message.reply_text.assert_called_once_with("No scheduled jobs.")
+
+
+async def test_list_with_jobs(update, context, mock_scheduler):
+    """List with jobs formats them correctly."""
+    mock_scheduler.list_jobs.return_value = [
+        {
+            "job_id": "abc-123",
+            "job_name": "daily-report",
+            "cron_expression": "0 9 * * *",
+            "is_active": 1,
+        },
+        {
+            "job_id": "def-456",
+            "job_name": "weekly-backup",
+            "cron_expression": "0 0 * * 0",
+            "is_active": 0,
+        },
+    ]
+    context.args = ["list"]
+    await schedule_command(update, context)
+    html = update.message.reply_html.call_args[0][0]
+    assert "daily-report" in html
+    assert "active" in html
+    assert "weekly-backup" in html
+    assert "paused" in html
+    assert "abc-123" in html
+
+
+async def test_add_success(update, context, mock_scheduler, tmp_dir):
+    """Add creates a job with correct parameters."""
+    context.args = ["add", "my-job", "0", "9", "*", "*", "1-5", "Run", "status", "check"]
+    await schedule_command(update, context)
+
+    mock_scheduler.add_job.assert_called_once_with(
+        job_name="my-job",
+        cron_expression="0 9 * * 1-5",
+        prompt="Run status check",
+        target_chat_ids=[12345],
+        working_directory=tmp_dir,
+        created_by=67890,
+    )
+    html = update.message.reply_html.call_args[0][0]
+    assert "my-job" in html
+    assert "job-123" in html
+
+
+async def test_add_too_few_args(update, context):
+    """Add with insufficient args shows usage."""
+    context.args = ["add", "my-job", "0", "9"]
+    await schedule_command(update, context)
+    update.message.reply_html.assert_called_once()
+    assert "Usage" in update.message.reply_html.call_args[0][0]
+
+
+async def test_add_failure(update, context, mock_scheduler):
+    """Add handles scheduler errors gracefully."""
+    mock_scheduler.add_job.side_effect = ValueError("Invalid cron expression")
+    context.args = ["add", "bad-job", "x", "y", "z", "a", "b", "Do", "something"]
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "Failed" in update.message.reply_text.call_args[0][0]
+
+
+async def test_remove(update, context, mock_scheduler):
+    """Remove calls scheduler.remove_job."""
+    context.args = ["remove", "job-123"]
+    await schedule_command(update, context)
+    mock_scheduler.remove_job.assert_called_once_with("job-123")
+    html = update.message.reply_html.call_args[0][0]
+    assert "job-123" in html
+    assert "removed" in html
+
+
+async def test_remove_no_id(update, context):
+    """Remove without job_id shows usage."""
+    context.args = ["remove"]
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "Usage" in update.message.reply_text.call_args[0][0]
+
+
+async def test_pause_success(update, context, mock_scheduler):
+    """Pause calls scheduler.pause_job."""
+    context.args = ["pause", "job-123"]
+    await schedule_command(update, context)
+    mock_scheduler.pause_job.assert_called_once_with("job-123")
+    html = update.message.reply_html.call_args[0][0]
+    assert "paused" in html
+
+
+async def test_pause_not_found(update, context, mock_scheduler):
+    """Pause with unknown job_id shows not found."""
+    mock_scheduler.pause_job.return_value = False
+    context.args = ["pause", "unknown-id"]
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "not found" in update.message.reply_text.call_args[0][0]
+
+
+async def test_pause_no_id(update, context):
+    """Pause without job_id shows usage."""
+    context.args = ["pause"]
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "Usage" in update.message.reply_text.call_args[0][0]
+
+
+async def test_resume_success(update, context, mock_scheduler):
+    """Resume calls scheduler.resume_job."""
+    context.args = ["resume", "job-123"]
+    await schedule_command(update, context)
+    mock_scheduler.resume_job.assert_called_once_with("job-123")
+    html = update.message.reply_html.call_args[0][0]
+    assert "resumed" in html
+
+
+async def test_resume_not_found(update, context, mock_scheduler):
+    """Resume with unknown job_id shows failure message."""
+    mock_scheduler.resume_job.return_value = False
+    context.args = ["resume", "unknown-id"]
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "not found" in update.message.reply_text.call_args[0][0]
+
+
+async def test_resume_no_id(update, context):
+    """Resume without job_id shows usage."""
+    context.args = ["resume"]
+    await schedule_command(update, context)
+    update.message.reply_text.assert_called_once()
+    assert "Usage" in update.message.reply_text.call_args[0][0]

--- a/tests/unit/test_scheduler/test_misfire_config.py
+++ b/tests/unit/test_scheduler/test_misfire_config.py
@@ -1,0 +1,37 @@
+"""Tests for scheduler misfire configuration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.events.bus import EventBus
+from src.scheduler.scheduler import JobScheduler
+from src.storage.database import DatabaseManager
+
+
+class TestSchedulerMisfireConfig:
+    """Verify APScheduler is configured for resilient job execution."""
+
+    @pytest.fixture
+    def scheduler(self, tmp_path):
+        event_bus = EventBus()
+        db_manager = MagicMock(spec=DatabaseManager)
+        return JobScheduler(
+            event_bus=event_bus,
+            db_manager=db_manager,
+            default_working_directory=tmp_path,
+        )
+
+    def test_misfire_grace_time_is_none(self, scheduler):
+        """misfire_grace_time=None ensures jobs always run, no matter how late."""
+        job_defaults = scheduler._scheduler._job_defaults
+        assert job_defaults.get("misfire_grace_time") is None, (
+            "misfire_grace_time must be None to guarantee late jobs still fire"
+        )
+
+    def test_coalesce_is_enabled(self, scheduler):
+        """coalesce=True merges multiple missed runs into a single execution."""
+        job_defaults = scheduler._scheduler._job_defaults
+        assert job_defaults.get("coalesce") is True, (
+            "coalesce must be True to prevent spam-firing missed runs"
+        )

--- a/tests/unit/test_sdd_handler.py
+++ b/tests/unit/test_sdd_handler.py
@@ -1,0 +1,341 @@
+"""Unit tests for the /sdd command handler."""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.bot.handlers.sdd_handler import (
+    _build_sdd_prompt,
+    _extract_issue_number,
+    _is_github_issue_url,
+    sdd_command,
+)
+from src.config import create_test_config
+from src.config.features import FeatureFlags
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_github_issue_url()
+# ---------------------------------------------------------------------------
+
+
+def test_is_github_issue_url_valid():
+    """A standard GitHub issue URL is recognised correctly."""
+    assert _is_github_issue_url("https://github.com/owner/repo/issues/5") is True
+
+
+def test_is_github_issue_url_valid_with_trailing_text():
+    """URL embedded in surrounding whitespace is still recognised."""
+    assert _is_github_issue_url("  https://github.com/owner/repo/issues/42  ") is True
+
+
+def test_is_github_issue_url_free_text():
+    """Plain free-text descriptions are NOT treated as URLs."""
+    assert _is_github_issue_url("Add dark mode to settings page") is False
+
+
+def test_is_github_issue_url_malformed():
+    """A URL that looks like GitHub but lacks the /issues/ path returns False."""
+    assert _is_github_issue_url("https://github.com/owner/repo/pull/5") is False
+
+
+def test_is_github_issue_url_http():
+    """http:// scheme is also accepted."""
+    assert _is_github_issue_url("http://github.com/owner/repo/issues/1") is True
+
+
+def test_is_github_issue_url_non_github():
+    """Non-GitHub URLs return False."""
+    assert _is_github_issue_url("https://gitlab.com/owner/repo/issues/5") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for _extract_issue_number()
+# ---------------------------------------------------------------------------
+
+
+def test_extract_issue_number_returns_int():
+    """Issue number is extracted as an integer from a valid URL."""
+    result = _extract_issue_number("https://github.com/owner/repo/issues/42")
+    assert result == 42
+
+
+def test_extract_issue_number_returns_none_for_free_text():
+    """Returns None when the input is not a GitHub issue URL."""
+    result = _extract_issue_number("Add dark mode")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_sdd_prompt()
+# ---------------------------------------------------------------------------
+
+
+def test_build_sdd_prompt_url_contains_gh_fetch_instruction():
+    """When is_url=True the prompt includes the gh issue view instruction."""
+    url = "https://github.com/owner/repo/issues/5"
+    prompt = _build_sdd_prompt(
+        arg=url,
+        working_dir=Path("/some/repo"),
+        protected_branches=["main", "master"],
+        is_url=True,
+    )
+    assert "gh issue view" in prompt
+    assert url in prompt
+
+
+def test_build_sdd_prompt_url_contains_protected_branches():
+    """Protected branches are injected into the URL-mode prompt."""
+    prompt = _build_sdd_prompt(
+        arg="https://github.com/owner/repo/issues/1",
+        working_dir=Path("/repo"),
+        protected_branches=["main", "master", "develop"],
+        is_url=True,
+    )
+    assert "main" in prompt
+    assert "master" in prompt
+    assert "develop" in prompt
+
+
+def test_build_sdd_prompt_free_text_no_gh_fetch():
+    """When is_url=False the prompt does NOT contain a gh issue view fetch call."""
+    prompt = _build_sdd_prompt(
+        arg="Add dark mode to settings page",
+        working_dir=Path("/repo"),
+        protected_branches=["main"],
+        is_url=False,
+    )
+    # The fetch instruction references the URL directly — should be absent for free text
+    assert "gh issue view https://" not in prompt
+    assert "Add dark mode to settings page" in prompt
+
+
+def test_build_sdd_prompt_free_text_description_in_prompt():
+    """Free-text description is passed verbatim into the prompt."""
+    description = "Improve pagination in the users list"
+    prompt = _build_sdd_prompt(
+        arg=description,
+        working_dir=Path("/repo"),
+        protected_branches=[],
+        is_url=False,
+    )
+    assert description in prompt
+
+
+def test_build_sdd_prompt_working_dir_in_prompt():
+    """Working directory path appears in the prompt."""
+    prompt = _build_sdd_prompt(
+        arg="Fix login bug",
+        working_dir=Path("/home/user/myproject"),
+        protected_branches=["main"],
+        is_url=False,
+    )
+    assert "/home/user/myproject" in prompt
+
+
+def test_build_sdd_prompt_contains_agent_file_instructions():
+    """Prompt instructs Claude to write all three .agent/ files."""
+    prompt = _build_sdd_prompt(
+        arg="Some task",
+        working_dir=Path("/repo"),
+        protected_branches=["main"],
+        is_url=False,
+    )
+    assert ".agent/planning/sdd.md" in prompt
+    assert ".agent/context/files.md" in prompt
+    assert ".agent/context/approach.md" in prompt
+
+
+def test_build_sdd_prompt_restrictions_present():
+    """Prompt must explicitly forbid modifying source files, opening PRs, running tests."""
+    prompt = _build_sdd_prompt(
+        arg="Some task",
+        working_dir=Path("/repo"),
+        protected_branches=["main"],
+        is_url=False,
+    )
+    assert "DO NOT modify any existing source file" in prompt
+    assert "DO NOT open a Pull Request" in prompt
+    assert "DO NOT run tests" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Tests for sdd_command() handler — feature flag disabled
+# ---------------------------------------------------------------------------
+
+
+def _make_update(text: str) -> MagicMock:
+    """Build a minimal Telegram Update mock."""
+    update = MagicMock()
+    update.effective_user.id = 99
+    update.message.text = text
+    update.message.reply_text = AsyncMock(return_value=MagicMock(edit_text=AsyncMock()))
+    return update
+
+
+def _make_context(settings, claude_integration=None, user_data=None) -> MagicMock:
+    """Build a minimal PTB context mock."""
+    context = MagicMock()
+    context.bot_data = {
+        "settings": settings,
+        "claude_integration": claude_integration,
+        "audit_logger": None,
+    }
+    context.user_data = user_data or {}
+    return context
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def settings_sdd_enabled(tmp_dir):
+    return create_test_config(
+        approved_directory=str(tmp_dir),
+        agentic_mode=True,
+        enable_sdd=True,
+    )
+
+
+@pytest.fixture
+def settings_sdd_disabled(tmp_dir):
+    return create_test_config(
+        approved_directory=str(tmp_dir),
+        agentic_mode=True,
+        enable_sdd=False,
+    )
+
+
+async def test_sdd_command_disabled_replies_and_does_not_call_claude(
+    settings_sdd_disabled,
+):
+    """When enable_sdd=False the handler replies disabled message without calling Claude."""
+    claude_integration = AsyncMock()
+    update = _make_update("/sdd https://github.com/owner/repo/issues/1")
+    context = _make_context(settings_sdd_disabled, claude_integration)
+
+    await sdd_command(update, context)
+
+    update.message.reply_text.assert_called_once_with("SDD command is disabled.")
+    claude_integration.run_command.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for sdd_command() — no argument
+# ---------------------------------------------------------------------------
+
+
+async def test_sdd_command_no_arg_replies_usage_and_does_not_call_claude(
+    settings_sdd_enabled,
+):
+    """When /sdd is sent with no argument the handler replies with usage help."""
+    claude_integration = AsyncMock()
+    update = _make_update("/sdd")
+    context = _make_context(settings_sdd_enabled, claude_integration)
+
+    await sdd_command(update, context)
+
+    call_args = update.message.reply_text.call_args
+    reply_text = call_args[0][0]
+    assert "Usage" in reply_text or "usage" in reply_text.lower() or "/sdd" in reply_text
+    claude_integration.run_command.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for sdd_command() — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_sdd_command_happy_path_calls_run_command_and_edits_message(
+    settings_sdd_enabled,
+):
+    """Happy path: run_command is called and the progress message is edited with the result."""
+    fake_response = MagicMock()
+    fake_response.content = "Branch Feat/Issue5AddDarkMode created. Files written."
+    fake_response.session_id = "sess-abc"
+
+    claude_integration = MagicMock()
+    claude_integration.run_command = AsyncMock(return_value=fake_response)
+
+    progress_msg = MagicMock()
+    progress_msg.edit_text = AsyncMock()
+
+    update = _make_update("/sdd https://github.com/owner/repo/issues/5")
+    update.message.reply_text = AsyncMock(return_value=progress_msg)
+
+    context = _make_context(settings_sdd_enabled, claude_integration)
+
+    await sdd_command(update, context)
+
+    claude_integration.run_command.assert_called_once()
+    # The prompt passed must contain the issue URL
+    call_kwargs = claude_integration.run_command.call_args
+    prompt_used = call_kwargs[1].get("prompt") or call_kwargs[0][0]
+    assert "github.com" in prompt_used
+
+    # Progress message must be edited with the response content
+    progress_msg.edit_text.assert_called_once()
+    edit_text_arg = progress_msg.edit_text.call_args[0][0]
+    assert "Feat/Issue5AddDarkMode" in edit_text_arg or "Branch" in edit_text_arg
+
+
+async def test_sdd_command_session_id_stored_after_success(settings_sdd_enabled):
+    """A new session_id returned by Claude is stored in user_data."""
+    fake_response = MagicMock()
+    fake_response.content = "Done."
+    fake_response.session_id = "new-session-xyz"
+
+    claude_integration = MagicMock()
+    claude_integration.run_command = AsyncMock(return_value=fake_response)
+
+    progress_msg = MagicMock()
+    progress_msg.edit_text = AsyncMock()
+
+    update = _make_update("/sdd Add some feature")
+    update.message.reply_text = AsyncMock(return_value=progress_msg)
+
+    context = _make_context(settings_sdd_enabled, claude_integration)
+
+    await sdd_command(update, context)
+
+    assert context.user_data.get("claude_session_id") == "new-session-xyz"
+
+
+# ---------------------------------------------------------------------------
+# Tests for FeatureFlags.sdd_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_feature_flags_sdd_enabled_true(tmp_dir):
+    """sdd_enabled returns True when enable_sdd=True in settings."""
+    settings = create_test_config(
+        approved_directory=str(tmp_dir),
+        enable_sdd=True,
+    )
+    flags = FeatureFlags(settings)
+    assert flags.sdd_enabled is True
+
+
+def test_feature_flags_sdd_enabled_false(tmp_dir):
+    """sdd_enabled returns False when enable_sdd=False in settings."""
+    settings = create_test_config(
+        approved_directory=str(tmp_dir),
+        enable_sdd=False,
+    )
+    flags = FeatureFlags(settings)
+    assert flags.sdd_enabled is False
+
+
+def test_feature_flags_is_feature_enabled_sdd(tmp_dir):
+    """is_feature_enabled('sdd') reflects the sdd_enabled property."""
+    settings_on = create_test_config(approved_directory=str(tmp_dir), enable_sdd=True)
+    settings_off = create_test_config(approved_directory=str(tmp_dir), enable_sdd=False)
+
+    assert FeatureFlags(settings_on).is_feature_enabled("sdd") is True
+    assert FeatureFlags(settings_off).is_feature_enabled("sdd") is False


### PR DESCRIPTION
## Que hace este PR?

- Agrega el comando `/topics add|list|delete` para registrar proyectos desde dentro de un topic de Telegram, sin tocar archivos de config
- Si se pasa una `git_url`, clona el repo en el path indicado antes de registrar; si falla, no registra
- Nueva tabla `projects` en SQLite (migration 5) como fuente de verdad dinámica
- El `projects.yaml` sigue funcionando (backward compatible) — DB-only es el nuevo modo

## Por que?

La configuración actual de project threads es 100% estática (YAML + restart). Este PR permite registrar un topic desde Telegram en tiempo real: el usuario crea el topic en la UI, manda `/topics add` desde adentro, y queda registrado al instante.

## Como probarlo?

- [ ] Crear un grupo de Telegram con forum topics habilitado
- [ ] Agregar el bot con permisos de admin
- [ ] Crear un topic manualmente en la UI de Telegram
- [ ] Desde dentro del topic: `/topics add myapp "Mi App" /workspace/myapp`
- [ ] Verificar respuesta de éxito y que el topic queda vinculado al proyecto
- [ ] `/topics list` — debe mostrar el proyecto registrado
- [ ] `/topics delete myapp` — debe eliminar el mapping
- [ ] Probar con `git_url`: `/topics add myapp "Mi App" /workspace/myapp https://github.com/org/repo`
- [ ] Probar clone fallido (repo privado sin auth) — debe mostrar error sin registrar
- [ ] Verificar que sin `PROJECTS_CONFIG_PATH` el bot inicia sin error (DB-only mode)