### PR TITLE
fix: resolve message truncation with colon ending

### DIFF
--- a/src/bot/utils/formatting.py
+++ b/src/bot/utils/formatting.py
@@ -71,7 +71,9 @@ class ResponseFormatter:
         """Determine if semantic chunking is needed."""
         # Use semantic chunking for complex content with multiple code blocks,
         # file operations, or very long text
-        code_block_count = text.count("```")
+        # NOTE: text at this point is already HTML (from _clean_text /
+        # markdown_to_telegram_html), so we count <pre> tags, not ``` fences.
+        code_block_count = text.count("<pre>")
         has_file_operations = any(
             indicator in text
             for indicator in [
@@ -211,37 +213,49 @@ class ResponseFormatter:
         return chunks
 
     def _identify_sections(self, text: str) -> List[dict]:
-        """Identify different content types in the text."""
+        """Identify different content types in the text.
+
+        At this point *text* is already HTML (converted by markdown_to_telegram_html),
+        so code blocks are identified by <pre> / </pre> tags, not ``` fences.
+        """
         sections = []
         lines = text.split("\n")
-        current_section = {"type": "text", "content": "", "start_line": 0}
+        current_section: dict = {"type": "text", "content": "", "start_line": 0}
         in_code_block = False
 
         for i, line in enumerate(lines):
-            # Check for code block markers
-            if line.strip().startswith("```"):
-                if not in_code_block:
-                    # Start of code block
-                    if current_section["content"].strip():
-                        sections.append(current_section)
-                    in_code_block = True
-                    current_section = {
-                        "type": "code_block",
-                        "content": line + "\n",
-                        "start_line": i,
-                    }
-                else:
-                    # End of code block
-                    current_section["content"] += line + "\n"
+            opens_pre = "<pre>" in line or "<pre><code" in line
+            closes_pre = "</pre>" in line
+
+            # Handle single-line code blocks: open and close on the same line
+            if opens_pre and closes_pre and not in_code_block:
+                if current_section["content"].strip():
                     sections.append(current_section)
-                    in_code_block = False
-                    current_section = {
-                        "type": "text",
-                        "content": "",
-                        "start_line": i + 1,
-                    }
+                sections.append({"type": "code_block", "content": line + "\n", "start_line": i})
+                current_section = {"type": "text", "content": "", "start_line": i + 1}
+                in_code_block = False
+
+            # Start of code block
+            elif opens_pre and not in_code_block:
+                if current_section["content"].strip():
+                    sections.append(current_section)
+                in_code_block = True
+                current_section = {
+                    "type": "code_block",
+                    "content": line + "\n",
+                    "start_line": i,
+                }
+
+            # End of code block
+            elif closes_pre and in_code_block:
+                current_section["content"] += line + "\n"
+                sections.append(current_section)
+                in_code_block = False
+                current_section = {"type": "text", "content": "", "start_line": i + 1}
+
             elif in_code_block:
                 current_section["content"] += line + "\n"
+
             else:
                 # Check for file operation patterns
                 if self._is_file_operation_line(line):
@@ -289,30 +303,42 @@ class ResponseFormatter:
         return any(indicator in line for indicator in file_indicators)
 
     def _chunk_code_block(self, section: dict) -> List[dict]:
-        """Handle code block chunking."""
+        """Handle code block chunking.
+
+        The section content is already HTML (<pre>...</pre>) at this point.
+        We chunk it by closing and reopening the <pre><code> tag at safe points.
+        """
         content = section["content"]
         if len(content) <= self.max_code_block_length:
             return [{"type": "code_block", "content": content, "format": "single"}]
 
-        # Split large code blocks
         chunks = []
         lines = content.split("\n")
-        current_chunk = lines[0] + "\n"  # Start with the ``` line
+        if not lines:
+            return [{"type": "code_block", "content": content, "format": "single"}]
 
-        for line in lines[1:-1]:  # Skip first and last ``` lines
-            if len(current_chunk + line + "\n```\n") > self.max_code_block_length:
-                current_chunk += "```"
-                chunks.append(
-                    {"type": "code_block", "content": current_chunk, "format": "split"}
-                )
-                current_chunk = "```\n" + line + "\n"
+        opening_tag = lines[0]  # e.g. '<pre><code class="language-python">'
+
+        # Collect code lines (skip opening tag line, break on closing tag)
+        code_lines: List[str] = []
+        for ln in lines[1:]:
+            stripped = ln.strip()
+            if stripped in ("</code></pre>", "</pre>"):
+                break
+            code_lines.append(ln)
+
+        current_chunk = opening_tag + "\n"
+        for line in code_lines:
+            test = current_chunk + line + "\n</code></pre>"
+            if len(test) > self.max_code_block_length and current_chunk != opening_tag + "\n":
+                current_chunk += "</code></pre>"
+                chunks.append({"type": "code_block", "content": current_chunk, "format": "split"})
+                current_chunk = "<pre><code>\n" + line + "\n"
             else:
                 current_chunk += line + "\n"
 
-        current_chunk += lines[-1]  # Add the closing ```
-        chunks.append(
-            {"type": "code_block", "content": current_chunk, "format": "split"}
-        )
+        current_chunk += "</code></pre>"
+        chunks.append({"type": "code_block", "content": current_chunk, "format": "split"})
 
         return chunks
 
@@ -456,14 +482,15 @@ class ResponseFormatter:
         """
 
         def _truncate_code(m: re.Match) -> str:  # type: ignore[type-arg]
-            full = m.group(0)
+            full: str = m.group(0)
             if len(full) > self.max_code_block_length:
-                # Re-extract and truncate the inner content
+                # Re-extract and truncate the inner content.
+                # NOTE: m.group(1) is already HTML-escaped (produced by
+                # markdown_to_telegram_html). Do NOT call escape_html() again
+                # or entities like &lt; would become &amp;lt; (double-escaped).
                 inner = m.group(1)
                 truncated = inner[: self.max_code_block_length - 80]
-                return (
-                    f"<pre><code>{escape_html(truncated)}\n... (truncated)</code></pre>"
-                )
+                return f"<pre><code>{truncated}\n... (truncated)</code></pre>"
             return full
 
         return re.sub(
@@ -474,27 +501,38 @@ class ResponseFormatter:
         )
 
     def _split_message(self, text: str) -> List[FormattedMessage]:
-        """Split long messages while preserving formatting."""
+        """Split long messages while preserving formatting.
+
+        Split strategy (Bug 1 fix):
+        - Inside a code block: close the tag, split, reopen with language class (Bug 4 fix).
+        - Outside a code block: prefer paragraph boundaries (\\n\\n) over line boundaries,
+          so messages don't end with a bare ':' on a line.
+        """
         if not text or not text.strip():
             return []
         if len(text) <= self.max_message_length:
             return [FormattedMessage(text)]
 
-        messages = []
+        messages: List[FormattedMessage] = []
         current_lines: List[str] = []
         current_length = 0
         in_code_block = False
+        current_code_lang = ""  # Bug 4: record language class for re-opening
 
         lines = text.split("\n")
 
         for line in lines:
             line_length = len(line) + 1  # +1 for newline
 
-            # Track HTML <pre> code block state
+            # Track HTML <pre> code block state AND extract language class
             if "<pre>" in line or "<pre><code" in line:
                 in_code_block = True
+                # Extract class="language-xxx" for Bug 4
+                lang_m = re.search(r'class="([^"]+)"', line)
+                current_code_lang = lang_m.group(1) if lang_m else ""
             if "</pre>" in line:
                 in_code_block = False
+                current_code_lang = ""
 
             # If this is a very long line that exceeds limit by itself, split it
             if line_length > self.max_message_length:
@@ -516,8 +554,13 @@ class ResponseFormatter:
                         current_lines = []
                         current_length = 0
                         if in_code_block:
-                            current_lines.append("<pre><code>")
-                            current_length = 12
+                            # Bug 4 fix: preserve language class when reopening
+                            if current_code_lang:
+                                reopen = f'<pre><code class="{current_code_lang}">'
+                            else:
+                                reopen = "<pre><code>"
+                            current_lines.append(reopen)
+                            current_length = len(reopen) + 1
 
                     current_lines.append(chunk)
                     current_length += chunk_length
@@ -526,16 +569,34 @@ class ResponseFormatter:
             # Check if adding this line would exceed the limit
             if current_length + line_length > self.max_message_length and current_lines:
                 if in_code_block:
+                    # Inside a code block: close the tag, split, reopen with lang
                     current_lines.append("</code></pre>")
-
-                messages.append(FormattedMessage("\n".join(current_lines)))
-
-                current_lines = []
-                current_length = 0
-
-                if in_code_block:
-                    current_lines.append("<pre><code>")
-                    current_length = 12
+                    messages.append(FormattedMessage("\n".join(current_lines)))
+                    current_lines = []
+                    current_length = 0
+                    if current_code_lang:
+                        reopen = f'<pre><code class="{current_code_lang}">'
+                    else:
+                        reopen = "<pre><code>"
+                    current_lines.append(reopen)
+                    current_length = len(reopen) + 1
+                else:
+                    # Bug 1 fix: prefer paragraph boundary (\\n\\n) for non-code splits
+                    joined = "\n".join(current_lines)
+                    para_pos = joined.rfind("\n\n")
+                    min_chunk = len(joined) // 8  # guard: don't split too early
+                    if para_pos > min_chunk:
+                        # Split at paragraph boundary
+                        first_part = joined[:para_pos]
+                        second_part = joined[para_pos:].lstrip("\n")
+                        messages.append(FormattedMessage(first_part))
+                        current_lines = second_part.split("\n") if second_part else []
+                        current_length = sum(len(l) + 1 for l in current_lines)
+                    else:
+                        # No good paragraph boundary — fall back to line boundary
+                        messages.append(FormattedMessage(joined))
+                        current_lines = []
+                        current_length = 0
 
             current_lines.append(line)
             current_length += line_length

--- a/tests/unit/test_bot/test_formatting.py
+++ b/tests/unit/test_bot/test_formatting.py
@@ -528,3 +528,138 @@ class TestOversizedResponseIntegration:
             assert (
                 len(msg.text) <= TELEGRAM_HARD_LIMIT
             ), f"Chunk {i} is {len(msg.text)} chars (limit {TELEGRAM_HARD_LIMIT})"
+
+    def test_colon_ending_pattern_not_truncated(self, formatter):
+        """Claude's 'header:\\n\\ncontent' pattern must NOT leave ':' as last char of a chunk.
+
+        Regression test for the primary bug: _split_message now prefers paragraph
+        boundaries (\\n\\n) over line boundaries, so 'Here are the changes:\\n\\n'
+        splits *after* the blank line, not after the ':' line.
+        """
+        header = "I've made the following changes:\n\n"
+        items = "\n".join(
+            f"{i}. **Step {i}**: Modified the function to handle edge case {i}"
+            for i in range(1, 80)
+        )
+        text = header + items  # > 4000 chars
+
+        messages = formatter.format_claude_response(text)
+        assert len(messages) > 1
+        first = messages[0].text.rstrip()
+        assert not first.endswith(":"), (
+            f"First chunk must NOT end with ':', got: ...{first[-80:]!r}"
+        )
+        for i, msg in enumerate(messages):
+            assert len(msg.text) <= TELEGRAM_HARD_LIMIT, (
+                f"Chunk {i} is {len(msg.text)} chars"
+            )
+
+    def test_split_prefers_paragraph_boundary(self, formatter):
+        """_split_message should prefer paragraph boundary over bare line boundary.
+
+        When the split point falls in the middle of a paragraph, _split_message
+        looks for the nearest \\n\\n and splits there — not mid-sentence.
+        This means 'header:\\n\\nbody' splits after the blank line, not after ':'.
+        """
+        # Build text where the first paragraph ends with ':' and the second is long
+        para1 = "Summary of changes:\n\n"
+        body_lines = [
+            f"{i}. **Item {i}**: description for item number {i}"
+            for i in range(1, 250)  # enough to exceed 4000 chars
+        ]
+        body = "\n".join(body_lines)
+        text = para1 + body  # > 4000 chars, ':' is at end of para1
+
+        assert len(text) > formatter.max_message_length, (
+            f"Test setup error: text is {len(text)} chars but limit is "
+            f"{formatter.max_message_length}"
+        )
+
+        messages = formatter._split_message(text)
+        assert len(messages) > 1, (
+            f"Text is {len(text)} chars, should split (limit={formatter.max_message_length})"
+        )
+        first = messages[0].text.rstrip()
+        # The split should be at \\n\\n (after para1), so first msg ends at the blank line,
+        # NOT at ':'
+        assert not first.endswith(":"), (
+            f"First chunk must not end with ':' (should split at \\n\\n), "
+            f"got: ...{first[-60:]!r}"
+        )
+
+    def test_split_preserves_code_block_language_class(self, formatter):
+        """Code blocks split across messages must preserve the language class attribute."""
+        code_lines = "\n".join(f"    x_{i} = process(item_{i})" for i in range(200))
+        text = f"```python\ndef big_fn():\n{code_lines}\n```"
+
+        messages = formatter.format_claude_response(text)
+        # Find messages that reopen a code block (contain <pre><code> without </code>)
+        reopened = [
+            m for m in messages
+            if "<pre><code>" in m.text and "</code></pre>" not in m.text
+        ]
+        if reopened:
+            # At least one reopened block should carry the language class
+            found_lang = any(
+                'class="language-python"' in m.text for m in reopened
+            )
+            assert found_lang, (
+                "Reopened code blocks should preserve language class; "
+                f"got: {[m.text[:60] for m in reopened]!r}"
+            )
+
+    def test_semantic_chunking_detects_html_code_blocks(self, formatter):
+        """_should_use_semantic_chunking must count <pre> tags (not ```) in HTML text."""
+        code_block = '<pre><code class="language-python">x = 1\n</code></pre>'
+        text_with_3_blocks = (
+            f"intro\n\n{code_block}\n\nmiddle\n\n"
+            f"{code_block}\n\nend\n\n{code_block}"
+        )
+        result = formatter._should_use_semantic_chunking(text_with_3_blocks)
+        assert result is True, "3 <pre> blocks should trigger semantic chunking"
+
+    def test_no_double_escape_in_truncated_code_block(self, formatter):
+        """_format_code_blocks must NOT double-escape HTML entities on truncation."""
+        # Simulate HTML-escaped content (what markdown_to_telegram_html produces)
+        inner = "if (a &lt; b &amp;&amp; c &gt; d) {}" * 500
+        html_block = f"<pre><code>{inner}</code></pre>"
+        result = formatter._format_code_blocks(html_block)
+        # Double-escape would produce &amp;lt; or &amp;amp;
+        assert "&amp;lt;" not in result, "must not double-escape &lt;"
+        assert "&amp;amp;" not in result, "must not double-escape &amp;"
+        assert "&lt;" in result or "truncated" in result  # original entities preserved
+
+    def test_split_paragraph_boundary_min_chunk_guard(self, formatter):
+        """Paragraph split must not produce trivially-small chunks (1/8 guard)."""
+        short_header = "Title:\n\n"
+        big_body = "A" * 4500  # single paragraph > 4000 chars
+        text = short_header + big_body
+
+        messages = formatter.format_claude_response(text)
+        assert len(messages) > 1
+        # Each chunk must be under Telegram's hard limit
+        for i, msg in enumerate(messages):
+            assert len(msg.text) <= TELEGRAM_HARD_LIMIT, (
+                f"Chunk {i} exceeds limit: {len(msg.text)} chars"
+            )
+
+    def test_identify_sections_single_line_code_block(self, formatter):
+        """_identify_sections must handle <pre>...</pre> on a single line."""
+        single_line = '<pre><code>short = 1</code></pre>'
+        sections = formatter._identify_sections(single_line)
+        assert len(sections) == 1
+        assert sections[0]["type"] == "code_block"
+        assert "short = 1" in sections[0]["content"]
+
+    def test_identify_sections_html_after_markdown_conversion(self, formatter):
+        """_identify_sections works on already-HTML text (not raw markdown)."""
+        # This is the exact state text is in when _identify_sections is called
+        html_text = (
+            "Normal paragraph.\n\n"
+            '<pre><code class="language-js">console.log("hi")\n</code></pre>\n\n'
+            "Another paragraph."
+        )
+        sections = formatter._identify_sections(html_text)
+        types = [s["type"] for s in sections]
+        assert "text" in types
+        assert "code_block" in types


### PR DESCRIPTION
## Summary
- Fix message truncation where messages ending with colon were cut off
- Improved paragraph boundary detection in message splitting
- Fixed HTML-based code block detection
- Removed double-escaping in code block truncation
- Preserved language class attribute on code block splits

## Test plan
- All 543 tests pass