### PR TITLE
feat(agentic): add /init and /compact commands

### DIFF
--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -324,6 +324,8 @@ class MessageOrchestrator:
         handlers = [
             ("start", self.agentic_start),
             ("new", self.agentic_new),
+            ("init", self.agentic_init),
+            ("compact", self.agentic_compact),
             ("status", self.agentic_status),
             ("verbose", self.agentic_verbose),
             ("repo", self.agentic_repo),
@@ -457,6 +459,8 @@ class MessageOrchestrator:
             commands = [
                 BotCommand("start", "Start the bot"),
                 BotCommand("new", "Start a fresh session"),
+                BotCommand("init", "Initialize project context"),
+                BotCommand("compact", "Compress conversation context"),
                 BotCommand("status", "Show session status"),
                 BotCommand("verbose", "Set output verbosity (0/1/2)"),
                 BotCommand("repo", "List repos / switch workspace"),
@@ -1752,4 +1756,274 @@ class MessageOrchestrator:
                 command="cd",
                 args=[project_name],
                 success=True,
+            )
+
+    # --- /init and /compact commands ---
+
+    async def agentic_init(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Handle /init — inject project description into Claude Code context.
+
+        Unlike /new (which destroys the session), /init preserves the session
+        and sends '/init [description]' as a prompt so Claude Code processes
+        it in the current conversation.
+        """
+        user_id = update.effective_user.id
+
+        # Parse optional project description (space-separated, multi-word)
+        raw_args = update.message.text.split()[1:]
+        description = " ".join(raw_args) if raw_args else None
+        prompt = f"/init {description}" if description else "/init"
+
+        await self._run_special_command(
+            update=update,
+            context=context,
+            prompt=prompt,
+            user_id=user_id,
+            command_name="init",
+        )
+
+    async def agentic_compact(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Handle /compact — compress Claude Code conversation context.
+
+        Requires an active session; /compact without history is a no-op for Claude.
+        Sends '/compact [reason]' as a prompt to trigger context compression.
+        """
+        user_id = update.effective_user.id
+
+        # Require an active session — /compact without prior context is meaningless
+        session_id = context.user_data.get("claude_session_id")
+        if not session_id:
+            await update.message.reply_text(
+                "⚠️ <b>No active session</b>\n\n"
+                "/compact requires an existing conversation. "
+                "Send a message first to start a session.",
+                parse_mode="HTML",
+            )
+            return
+
+        # Parse optional reason (space-separated, multi-word)
+        raw_args = update.message.text.split()[1:]
+        reason = " ".join(raw_args) if raw_args else None
+        prompt = f"/compact {reason}" if reason else "/compact"
+
+        await self._run_special_command(
+            update=update,
+            context=context,
+            prompt=prompt,
+            user_id=user_id,
+            command_name="compact",
+        )
+
+    async def _run_special_command(
+        self,
+        *,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+        prompt: str,
+        user_id: int,
+        command_name: str,
+    ) -> None:
+        """Execute a special command (/init, /compact) with streaming UI.
+
+        Reuses the streaming, progress, and response formatting from
+        agentic_text(), but sends a verbatim prompt so '/init' or '/compact'
+        reaches Claude Code unchanged.
+        """
+        # Rate limit check
+        rate_limiter = context.bot_data.get("rate_limiter")
+        if rate_limiter:
+            allowed, limit_message = await rate_limiter.check_rate_limit(user_id, 0.001)
+            if not allowed:
+                await update.message.reply_text(f"⏱️ {limit_message}")
+                return
+
+        chat = update.message.chat
+        await chat.send_action("typing")
+
+        verbose_level = self._get_verbose_level(context)
+
+        interrupt_event = asyncio.Event()
+        stop_kb = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Stop", callback_data=f"stop:{user_id}")]]
+        )
+        progress_msg = await update.message.reply_text(
+            "Working...", reply_markup=stop_kb
+        )
+
+        active_request = ActiveRequest(
+            user_id=user_id,
+            interrupt_event=interrupt_event,
+            progress_msg=progress_msg,
+        )
+        self._active_requests[user_id] = active_request
+
+        claude_integration = context.bot_data.get("claude_integration")
+        if not claude_integration:
+            self._active_requests.pop(user_id, None)
+            await progress_msg.edit_text(
+                "Claude integration not available. Check configuration.",
+                reply_markup=None,
+            )
+            return
+
+        current_dir = context.user_data.get(
+            "current_directory", self.settings.approved_directory
+        )
+        session_id = context.user_data.get("claude_session_id")
+
+        tool_log: List[Dict[str, Any]] = []
+        start_time = time.time()
+        mcp_images: List[ImageAttachment] = []
+
+        draft_streamer: Optional[DraftStreamer] = None
+        if self.settings.enable_stream_drafts and chat.type == "private":
+            draft_streamer = DraftStreamer(
+                bot=context.bot,
+                chat_id=chat.id,
+                draft_id=generate_draft_id(),
+                message_thread_id=update.message.message_thread_id,
+                throttle_interval=self.settings.stream_draft_interval,
+            )
+
+        on_stream = self._make_stream_callback(
+            verbose_level,
+            progress_msg,
+            tool_log,
+            start_time,
+            reply_markup=stop_kb,
+            mcp_images=mcp_images,
+            approved_directory=self.settings.approved_directory,
+            draft_streamer=draft_streamer,
+            interrupt_event=interrupt_event,
+        )
+
+        heartbeat = self._start_typing_heartbeat(chat)
+        success = True
+
+        try:
+            claude_response = await claude_integration.run_command(
+                prompt=prompt,
+                working_directory=current_dir,
+                user_id=user_id,
+                session_id=session_id,
+                on_stream=on_stream,
+                force_new=False,  # Preserve existing session
+                interrupt_event=interrupt_event,
+            )
+
+            context.user_data["claude_session_id"] = claude_response.session_id
+
+            from .handlers.message import _update_working_directory_from_claude_response
+
+            _update_working_directory_from_claude_response(
+                claude_response, context, self.settings, user_id
+            )
+
+            storage = context.bot_data.get("storage")
+            if storage:
+                try:
+                    await storage.save_claude_interaction(
+                        user_id=user_id,
+                        session_id=claude_response.session_id,
+                        prompt=prompt,
+                        response=claude_response,
+                        ip_address=None,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to log interaction", error=str(e))
+
+            from .utils.formatting import ResponseFormatter
+
+            formatter = ResponseFormatter(self.settings)
+            formatted_messages = formatter.format_claude_response(claude_response.content)
+
+        except Exception as e:
+            success = False
+            logger.error(
+                f"Claude {command_name} failed", error=str(e), user_id=user_id
+            )
+            from .handlers.message import _format_error_message
+            from .utils.formatting import FormattedMessage
+
+            formatted_messages = [
+                FormattedMessage(_format_error_message(e), parse_mode="HTML")
+            ]
+        finally:
+            heartbeat.cancel()
+            self._active_requests.pop(user_id, None)
+            if draft_streamer:
+                try:
+                    await draft_streamer.flush()
+                except Exception:
+                    logger.debug("Draft flush failed", user_id=user_id)
+
+        try:
+            await progress_msg.delete()
+        except Exception:
+            logger.debug("Failed to delete progress message")
+
+        # Send formatted response(s)
+        images: List[ImageAttachment] = mcp_images
+        caption_sent = False
+        if images and len(formatted_messages) == 1:
+            msg = formatted_messages[0]
+            if msg.text and len(msg.text) <= 1024:
+                try:
+                    caption_sent = await self._send_images(
+                        update,
+                        images,
+                        reply_to_message_id=update.message.message_id,
+                        caption=msg.text,
+                        caption_parse_mode=msg.parse_mode,
+                    )
+                except Exception as img_err:
+                    logger.warning("Image+caption send failed", error=str(img_err))
+
+        if not caption_sent:
+            for i, message in enumerate(formatted_messages):
+                if not message.text or not message.text.strip():
+                    continue
+                try:
+                    await update.message.reply_text(
+                        message.text,
+                        parse_mode=message.parse_mode,
+                        reply_markup=None,
+                        reply_to_message_id=(
+                            update.message.message_id if i == 0 else None
+                        ),
+                    )
+                    if i < len(formatted_messages) - 1:
+                        await asyncio.sleep(0.5)
+                except Exception:
+                    # Fallback: plain text
+                    await update.message.reply_text(
+                        message.text,
+                        reply_markup=None,
+                        reply_to_message_id=(
+                            update.message.message_id if i == 0 else None
+                        ),
+                    )
+
+            if images:
+                try:
+                    await self._send_images(
+                        update,
+                        images,
+                        reply_to_message_id=update.message.message_id,
+                    )
+                except Exception as img_err:
+                    logger.warning("Image send failed", error=str(img_err))
+
+        # Audit log
+        audit_logger = context.bot_data.get("audit_logger")
+        if audit_logger:
+            await audit_logger.log_command(
+                user_id=user_id,
+                command=command_name,
+                args=[prompt[:100]],
+                success=success,
             )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -83,7 +83,7 @@ def deps():
 
 
 def test_agentic_registers_6_commands(agentic_settings, deps):
-    """Agentic mode registers start, new, status, verbose, repo, restart commands."""
+    """Agentic mode registers start, new, init, compact, status, verbose, repo, restart commands."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     app = MagicMock()
     app.add_handler = MagicMock()
@@ -100,9 +100,11 @@ def test_agentic_registers_6_commands(agentic_settings, deps):
     ]
     commands = [h[0][0].commands for h in cmd_handlers]
 
-    assert len(cmd_handlers) == 6
+    assert len(cmd_handlers) == 8
     assert frozenset({"start"}) in commands
     assert frozenset({"new"}) in commands
+    assert frozenset({"init"}) in commands
+    assert frozenset({"compact"}) in commands
     assert frozenset({"status"}) in commands
     assert frozenset({"verbose"}) in commands
     assert frozenset({"repo"}) in commands
@@ -156,13 +158,13 @@ def test_agentic_registers_text_document_photo_handlers(agentic_settings, deps):
 
 
 async def test_agentic_bot_commands(agentic_settings, deps):
-    """Agentic mode returns 6 bot commands."""
+    """Agentic mode returns 8 bot commands."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     commands = await orchestrator.get_bot_commands()
 
-    assert len(commands) == 6
+    assert len(commands) == 8
     cmd_names = [c.command for c in commands]
-    assert cmd_names == ["start", "new", "status", "verbose", "repo", "restart"]
+    assert cmd_names == ["start", "new", "init", "compact", "status", "verbose", "repo", "restart"]
 
 
 async def test_classic_bot_commands(classic_settings, deps):
@@ -990,3 +992,359 @@ async def test_bot_suffixed_command_not_forwarded(agentic_settings, deps):
     ) as mock_claude:
         await orchestrator._handle_unknown_command(update, context)
         mock_claude.assert_not_called()
+
+
+# --- /init and /compact command tests ---
+
+
+def test_agentic_registers_8_commands(agentic_settings, deps):
+    """Agentic mode registers start, new, init, compact, status, verbose, repo, restart."""
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+    app = MagicMock()
+    app.add_handler = MagicMock()
+
+    orchestrator.register_handlers(app)
+
+    from telegram.ext import CommandHandler
+
+    cmd_handlers = [
+        call
+        for call in app.add_handler.call_args_list
+        if isinstance(call[0][0], CommandHandler)
+    ]
+    commands = [h[0][0].commands for h in cmd_handlers]
+
+    assert len(cmd_handlers) == 8
+    assert frozenset({"start"}) in commands
+    assert frozenset({"new"}) in commands
+    assert frozenset({"init"}) in commands
+    assert frozenset({"compact"}) in commands
+    assert frozenset({"status"}) in commands
+    assert frozenset({"verbose"}) in commands
+    assert frozenset({"repo"}) in commands
+    assert frozenset({"restart"}) in commands
+
+
+async def test_agentic_bot_commands_includes_init_and_compact(agentic_settings, deps):
+    """Agentic bot command list includes /init and /compact."""
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+    commands = await orchestrator.get_bot_commands()
+
+    assert len(commands) == 8
+    cmd_names = [c.command for c in commands]
+    assert "init" in cmd_names
+    assert "compact" in cmd_names
+    assert cmd_names == [
+        "start",
+        "new",
+        "init",
+        "compact",
+        "status",
+        "verbose",
+        "repo",
+        "restart",
+    ]
+
+
+async def _mock_special_command(orchestrator, update, context, prompt_prefix):
+    """Helper: capture kwargs passed to run_command and check the prompt."""
+    claude_integration = context.bot_data["claude_integration"]
+
+    # Set up mock response
+    mock_response = MagicMock()
+    mock_response.session_id = "test-session-123"
+    mock_response.content = "Claude processed the command."
+    mock_response.tools_used = []
+    mock_response.interrupted = False
+
+    async def run_command_side_effect(**kwargs):
+        # Store call kwargs for assertion below
+        run_command_call_kwargs.update(kwargs)
+        return mock_response
+
+    run_command_call_kwargs: dict = {}
+
+    claude_integration.run_command = AsyncMock(side_effect=run_command_side_effect)
+
+    # We need the handler to call _run_special_command which uses the real
+    # _run_special_command. We patch run_command to capture the kwargs.
+    return run_command_call_kwargs
+
+
+class TestAgenticSpecialCommands:
+    """Tests for /init and /compact handlers."""
+
+    async def test_init_command_no_args(self, agentic_settings, deps):
+        """Send /init without arguments → prompt is exactly '/init'."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+        mock_response = MagicMock()
+        mock_response.session_id = "session-abc"
+        mock_response.content = "Initialized."
+        mock_response.tools_used = []
+        mock_response.interrupted = False
+
+        run_command_kwargs: dict = {}
+
+        claude_integration = AsyncMock()
+        claude_integration.run_command = AsyncMock(
+            side_effect=lambda **kw: (
+                run_command_kwargs.update(kw) or run_command_kwargs,
+                mock_response,
+            )[-1]
+        )
+
+        update = MagicMock()
+        update.effective_user.id = 123
+        update.message.text = "/init"
+        update.message.message_id = 1
+        update.message.chat.type = "private"
+        update.message.chat.send_action = AsyncMock()
+        update.message.reply_text = AsyncMock()
+
+        progress_msg = AsyncMock()
+        progress_msg.delete = AsyncMock()
+        update.message.reply_text.return_value = progress_msg
+
+        context = MagicMock()
+        context.user_data = {}
+        context.bot_data = {
+            "settings": agentic_settings,
+            "claude_integration": claude_integration,
+            "storage": None,
+            "rate_limiter": None,
+            "audit_logger": None,
+        }
+
+        await orchestrator.agentic_init(update, context)
+
+        claude_integration.run_command.assert_called_once()
+        assert run_command_kwargs["prompt"] == "/init"
+        assert run_command_kwargs["force_new"] is False
+
+    async def test_init_command_with_description(self, agentic_settings, deps):
+        """Send /init with description → description is appended after /init."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+        mock_response = MagicMock()
+        mock_response.session_id = "session-abc"
+        mock_response.content = "Initialized."
+        mock_response.tools_used = []
+        mock_response.interrupted = False
+
+        run_command_kwargs: dict = {}
+
+        claude_integration = AsyncMock()
+        claude_integration.run_command = AsyncMock(
+            side_effect=lambda **kw: (
+                run_command_kwargs.update(kw) or run_command_kwargs,
+                mock_response,
+            )[-1]
+        )
+
+        update = MagicMock()
+        update.effective_user.id = 123
+        update.message.text = "/init My awesome project"
+        update.message.message_id = 1
+        update.message.chat.type = "private"
+        update.message.chat.send_action = AsyncMock()
+        update.message.reply_text = AsyncMock()
+
+        progress_msg = AsyncMock()
+        progress_msg.delete = AsyncMock()
+        update.message.reply_text.return_value = progress_msg
+
+        context = MagicMock()
+        context.user_data = {}
+        context.bot_data = {
+            "settings": agentic_settings,
+            "claude_integration": claude_integration,
+            "storage": None,
+            "rate_limiter": None,
+            "audit_logger": None,
+        }
+
+        await orchestrator.agentic_init(update, context)
+
+        claude_integration.run_command.assert_called_once()
+        assert "/init My awesome project" == run_command_kwargs["prompt"]
+
+    async def test_compact_requires_active_session(self, agentic_settings, deps):
+        """Send /compact without active session → reply warns user, Claude not called."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+        claude_integration = AsyncMock()
+        claude_integration.run_command = AsyncMock()
+
+        update = MagicMock()
+        update.effective_user.id = 123
+        update.message.text = "/compact"
+        update.message.reply_text = AsyncMock()
+
+        context = MagicMock()
+        context.user_data = {}  # No claude_session_id
+        context.bot_data = {
+            "claude_integration": claude_integration,
+        }
+
+        await orchestrator.agentic_compact(update, context)
+
+        claude_integration.run_command.assert_not_awaited()
+        update.message.reply_text.assert_called_once()
+        assert "No active session" in update.message.reply_text.call_args.args[0]
+
+    async def test_compact_command_no_args(self, agentic_settings, deps):
+        """Send /compact with active session → prompt is '/compact', session preserved."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+        mock_response = MagicMock()
+        mock_response.session_id = "session-abc"
+        mock_response.content = "Context compressed."
+        mock_response.tools_used = []
+        mock_response.interrupted = False
+
+        run_command_kwargs: dict = {}
+
+        claude_integration = AsyncMock()
+        claude_integration.run_command = AsyncMock(
+            side_effect=lambda **kw: (
+                run_command_kwargs.update(kw) or run_command_kwargs,
+                mock_response,
+            )[-1]
+        )
+
+        update = MagicMock()
+        update.effective_user.id = 123
+        update.message.text = "/compact"
+        update.message.message_id = 1
+        update.message.chat.type = "private"
+        update.message.chat.send_action = AsyncMock()
+        update.message.reply_text = AsyncMock()
+
+        progress_msg = AsyncMock()
+        progress_msg.delete = AsyncMock()
+        update.message.reply_text.return_value = progress_msg
+
+        context = MagicMock()
+        context.user_data = {"claude_session_id": "existing-session-xyz"}
+        context.bot_data = {
+            "settings": agentic_settings,
+            "claude_integration": claude_integration,
+            "storage": None,
+            "rate_limiter": None,
+            "audit_logger": None,
+        }
+
+        await orchestrator.agentic_compact(update, context)
+
+        claude_integration.run_command.assert_called_once()
+        assert run_command_kwargs["prompt"] == "/compact"
+        assert run_command_kwargs["session_id"] == "existing-session-xyz"
+        assert run_command_kwargs["force_new"] is False
+
+    async def test_compact_command_with_reason(self, agentic_settings, deps):
+        """Send /compact with reason → reason appended after /compact."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+        mock_response = MagicMock()
+        mock_response.session_id = "session-abc"
+        mock_response.content = "Context compressed."
+        mock_response.tools_used = []
+        mock_response.interrupted = False
+
+        run_command_kwargs: dict = {}
+
+        claude_integration = AsyncMock()
+        claude_integration.run_command = AsyncMock(
+            side_effect=lambda **kw: (
+                run_command_kwargs.update(kw) or run_command_kwargs,
+                mock_response,
+            )[-1]
+        )
+
+        update = MagicMock()
+        update.effective_user.id = 123
+        update.message.text = "/compact too much history"
+        update.message.message_id = 1
+        update.message.chat.type = "private"
+        update.message.chat.send_action = AsyncMock()
+        update.message.reply_text = AsyncMock()
+
+        progress_msg = AsyncMock()
+        progress_msg.delete = AsyncMock()
+        update.message.reply_text.return_value = progress_msg
+
+        context = MagicMock()
+        context.user_data = {"claude_session_id": "existing-session-xyz"}
+        context.bot_data = {
+            "settings": agentic_settings,
+            "claude_integration": claude_integration,
+            "storage": None,
+            "rate_limiter": None,
+            "audit_logger": None,
+        }
+
+        await orchestrator.agentic_compact(update, context)
+
+        claude_integration.run_command.assert_called_once()
+        assert "/compact too much history" == run_command_kwargs["prompt"]
+
+    async def test_compact_preserves_session_id_across_calls(self, agentic_settings, deps):
+        """Two consecutive /compact calls each use the session_id active at call time.
+
+        The first call uses the pre-existing session_id. After the first call,
+        context.user_data is updated with the response session_id (if different),
+        so the second call uses the updated value. Both calls remain in the same
+        conversation — only the reference in user_data changes.
+        """
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+        mock_response = MagicMock()
+        mock_response.session_id = "session-abc"
+        mock_response.content = "Context compressed."
+        mock_response.tools_used = []
+        mock_response.interrupted = False
+
+        session_ids: list = []
+
+        claude_integration = AsyncMock()
+        claude_integration.run_command = AsyncMock(
+            side_effect=lambda **kw: (
+                session_ids.append(kw.get("session_id")),
+                mock_response,
+            )[-1]
+        )
+
+        update = MagicMock()
+        update.effective_user.id = 123
+        update.message.message_id = 1
+        update.message.chat.type = "private"
+        update.message.chat.send_action = AsyncMock()
+        update.message.reply_text = AsyncMock()
+
+        progress_msg = AsyncMock()
+        progress_msg.delete = AsyncMock()
+        update.message.reply_text.return_value = progress_msg
+
+        context = MagicMock()
+        context.user_data = {"claude_session_id": "existing-session-xyz"}
+        context.bot_data = {
+            "settings": agentic_settings,
+            "claude_integration": claude_integration,
+            "storage": None,
+            "rate_limiter": None,
+            "audit_logger": None,
+        }
+
+        # First call — uses the pre-existing session_id from user_data
+        update.message.text = "/compact"
+        await orchestrator.agentic_compact(update, context)
+
+        # Second call — uses the session_id that was set by the first response
+        update.message.text = "/compact summarize"
+        await orchestrator.agentic_compact(update, context)
+
+        assert claude_integration.run_command.call_count == 2
+        # First call uses original session, second call uses what first response set
+        assert session_ids[0] == "existing-session-xyz"
+        assert session_ids[1] == "session-abc"


### PR DESCRIPTION
## Summary
- Map Claude Code CLI /init and /compact as Telegram bot commands in agentic mode
- /init [description] — inject project context into current session (preserves session)
- /compact [reason] — compress conversation context (requires active session)
- SDK has no native support; commands sent as verbatim prompt text
- Shared _run_special_command() engine avoids code duplication
- 6 new unit tests covering all command paths

## Test plan
- All 49 orchestrator tests pass