### PR TITLE
feat: daily session reset by timezone

### DIFF
--- a/src/claude/facade.py
+++ b/src/claude/facade.py
@@ -191,7 +191,7 @@ class ClaudeIntegration:
             for s in sessions
             if s.project_path == working_directory
             and bool(s.session_id)
-            and not s.is_expired(self.config.session_timeout_hours)
+            and not self.session_manager._is_session_expired(s)
         ]
 
         if not matching_sessions:
@@ -259,7 +259,7 @@ class ClaudeIntegration:
                 "total_cost": s.total_cost,
                 "message_count": s.message_count,
                 "tools_used": s.tools_used,
-                "expired": s.is_expired(self.config.session_timeout_hours),
+                "expired": self.session_manager._is_session_expired(s),
             }
             for s in sessions
         ]

--- a/src/claude/session.py
+++ b/src/claude/session.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional
+from zoneinfo import ZoneInfo
 
 import structlog
 
@@ -39,10 +40,35 @@ class ClaudeSession:
     tools_used: List[str] = field(default_factory=list)
     is_new_session: bool = False  # True if session hasn't been sent to Claude Code yet
 
-    def is_expired(self, timeout_hours: int) -> bool:
-        """Check if session has expired."""
-        age = datetime.now(UTC) - _to_utc(self.last_used)
-        return age > timedelta(hours=timeout_hours)
+    def is_expired(
+        self,
+        timeout_hours: int,
+        daily_reset_hour: Optional[int] = None,
+        daily_reset_tz: str = "UTC",
+    ) -> bool:
+        """Check if session has expired.
+
+        Expires if age exceeds timeout_hours OR if the session spans
+        the daily reset boundary (e.g. 3:00 AM local time).
+        """
+        now = datetime.now(UTC)
+        age = now - _to_utc(self.last_used)
+        if age > timedelta(hours=timeout_hours):
+            return True
+
+        if daily_reset_hour is not None:
+            tz = ZoneInfo(daily_reset_tz)
+            now_local = now.astimezone(tz)
+            today_reset = now_local.replace(
+                hour=daily_reset_hour, minute=0, second=0, microsecond=0
+            )
+            if now_local < today_reset:
+                today_reset -= timedelta(days=1)
+            last_used_local = _to_utc(self.last_used).astimezone(tz)
+            if last_used_local < today_reset:
+                return True
+
+        return False
 
     def update_usage(self, response: ClaudeResponse) -> None:
         """Update session with usage from response."""
@@ -123,6 +149,14 @@ class SessionManager:
         self.storage = storage
         self.active_sessions: Dict[str, ClaudeSession] = {}
 
+    def _is_session_expired(self, session: ClaudeSession) -> bool:
+        """Check if session is expired using all configured rules."""
+        return session.is_expired(
+            self.config.session_timeout_hours,
+            daily_reset_hour=self.config.session_daily_reset_hour,
+            daily_reset_tz=self.config.session_daily_reset_timezone,
+        )
+
     async def get_or_create_session(
         self,
         user_id: int,
@@ -147,14 +181,14 @@ class SessionManager:
                     session_owner=session.user_id,
                     requesting_user=user_id,
                 )
-            elif not session.is_expired(self.config.session_timeout_hours):
+            elif not self._is_session_expired(session):
                 logger.debug("Using active session", session_id=session_id)
                 return session
 
         # Try to load from storage (filtered by user_id)
         if session_id:
             session = await self.storage.load_session(session_id, user_id)
-            if session and not session.is_expired(self.config.session_timeout_hours):
+            if session and not self._is_session_expired(session):
                 self.active_sessions[session_id] = session
                 logger.info("Loaded session from storage", session_id=session_id)
                 return session
@@ -244,7 +278,7 @@ class SessionManager:
         expired_count = 0
 
         for session in all_sessions:
-            if session.is_expired(self.config.session_timeout_hours):
+            if self._is_session_expired(session):
                 await self.remove_session(session.session_id)
                 expired_count += 1
 
@@ -281,7 +315,7 @@ class SessionManager:
                 "turns": session.total_turns,
                 "messages": session.message_count,
                 "tools_used": session.tools_used,
-                "expired": session.is_expired(self.config.session_timeout_hours),
+                "expired": self._is_session_expired(session),
             }
 
         return None
@@ -293,7 +327,7 @@ class SessionManager:
         total_cost = sum(s.total_cost for s in sessions)
         total_messages = sum(s.message_count for s in sessions)
         active_sessions = [
-            s for s in sessions if not s.is_expired(self.config.session_timeout_hours)
+            s for s in sessions if not self._is_session_expired(s)
         ]
 
         return {

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -190,6 +190,16 @@ class Settings(BaseSettings):
     max_sessions_per_user: int = Field(
         DEFAULT_MAX_SESSIONS_PER_USER, description="Max concurrent sessions"
     )
+    session_daily_reset_hour: Optional[int] = Field(
+        default=None,
+        description="Hour of day (0-23) to force session reset. None = disabled.",
+        ge=0,
+        le=23,
+    )
+    session_daily_reset_timezone: str = Field(
+        default="UTC",
+        description="Timezone for daily reset hour (e.g. 'Europe/Lisbon')",
+    )
 
     # Features
     enable_mcp: bool = Field(False, description="Enable Model Context Protocol")


### PR DESCRIPTION
## Summary

Adds two settings — `SESSION_DAILY_RESET_HOUR` (0-23) and `SESSION_DAILY_RESET_TIMEZONE` (IANA tz string) — that force session expiry at a recurring daily boundary. A session whose `last_used` falls before today's reset hour (in the configured local timezone) is treated as expired in addition to the existing `SESSION_TIMEOUT_HOURS` rule.

## Why

The existing inactivity-based timeout works well for natural breaks but doesn't enforce a fresh start each day. Some users (myself included) prefer "every morning, the bot starts a fresh session" to avoid yesterday's working set leaking into today's first message — without needing to remember `/new`.

Two examples:

- Personal/journaling use: each day's first message should be a clean slate. `SESSION_DAILY_RESET_HOUR=3` + `SESSION_DAILY_RESET_TIMEZONE=Europe/Lisbon` ensures the 9am check-in starts fresh even if the previous session was at 11pm.
- Team/operational use: similar reasoning for daily standups, incident handoffs.

## What

**`src/claude/session.py`** — `ClaudeSession.is_expired()` gains two optional parameters (`daily_reset_hour`, `daily_reset_tz`); existing `(timeout_hours)` calls remain valid (defaults preserve previous behavior). New `SessionManager._is_session_expired(session)` helper threads both rules through one call site.

**`src/claude/facade.py`** — two existing `s.is_expired(self.config.session_timeout_hours)` callsites switch to `self.session_manager._is_session_expired(s)` so they pick up the daily rule.

**`src/config/settings.py`** — adds the two new settings:

```python
session_daily_reset_hour: Optional[int] = Field(
    default=None,  # disabled by default
    description="Hour of day (0-23) to force session reset. None = disabled.",
    ge=0, le=23,
)
session_daily_reset_timezone: str = Field(
    default="UTC",
    description="Timezone for daily reset hour (e.g. 'Europe/Lisbon')",
)
```

## How it works

The logic is a lazy expiry check, not a background scheduler:

```python
# (simplified)
now_local = datetime.now(UTC).astimezone(ZoneInfo(daily_reset_tz))
today_reset = now_local.replace(hour=daily_reset_hour, minute=0, second=0)
if now_local < today_reset:
    today_reset -= timedelta(days=1)
last_used_local = _to_utc(session.last_used).astimezone(tz)
if last_used_local < today_reset:
    return True  # expired
```

So a session created Tuesday 11pm and accessed Wednesday 9am — with reset at 3am Lisbon — is detected as expired the moment Wednesday's `is_expired()` runs. No timer, no race condition, no jobs to schedule.

## Compatibility

- Disabled by default (`session_daily_reset_hour = None`). Pure no-op when unset.
- All existing `is_expired(timeout_hours)` callsites keep working — the new params are optional with sensible defaults.

## Test plan

- [ ] With reset disabled (default), behavior unchanged — sessions only expire on inactivity timeout
- [ ] With `SESSION_DAILY_RESET_HOUR=3` and `TZ=Europe/Lisbon`: session created 11pm, query at 9am next day → fresh session
- [ ] Cross-DST transitions (zoneinfo handles correctly via `ZoneInfo`)
- [ ] Cross-timezone deployment: bot running in UTC, `SESSION_DAILY_RESET_TIMEZONE=America/New_York` → reset boundary follows NYC, not UTC

## Notes

Uses `zoneinfo.ZoneInfo` from stdlib (3.9+) — no new dependencies. The codebase already requires Python 3.11.