### PR TITLE
fix: isolate Claude sessions by Telegram topic

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Wrapper that loads the bot token from macOS Keychain and starts the bot.
+# Used by both manual runs and the LaunchAgent.
+set -euo pipefail
+
+REPO_DIR="/Users/jarvis/jarvis-hub/repos/tools/claude-code-telegram"
+cd "$REPO_DIR"
+
+# Hard guard: never run with ANTHROPIC_API_KEY set (forces OAuth via claude CLI).
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "ERROR: ANTHROPIC_API_KEY is set. This bot must run with OAuth via Claude CLI." >&2
+  echo "Unset it before launching." >&2
+  exit 2
+fi
+
+# Pull the Telegram bot token from Keychain.
+TOKEN="$(security find-generic-password \
+  -s "claude-code-telegram-bot" \
+  -a "ferd" \
+  -w 2>/dev/null || true)"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "ERROR: bot token not found in Keychain (service=claude-code-telegram-bot, account=ferd)." >&2
+  echo "Run: security add-generic-password -U -s claude-code-telegram-bot -a ferd -w '<TOKEN>'" >&2
+  exit 3
+fi
+
+export TELEGRAM_BOT_TOKEN="$TOKEN"
+
+# Ensure ecosystem CLIs are on PATH: claude (homebrew), linearctl (~/.npm-global/bin),
+# and other Jarvis tooling that skills may shell out to.
+export PATH="/Users/jarvis/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+exec "$REPO_DIR/.venv/bin/python" -m src.main "$@"

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -49,6 +49,9 @@ _MEDIA_TYPE_MAP = {
     "webp": "image/webp",
 }
 
+# Session-control flags must be scoped to each Telegram forum topic, not user-wide.
+_THREAD_SCOPED_SESSION_KEYS = ("force_new_session", "session_started")
+
 # Patterns that look like secrets/credentials in CLI arguments
 _SECRET_PATTERNS: List[re.Pattern[str]] = [
     # API keys / tokens (sk-ant-..., sk-..., ghp_..., gho_..., github_pat_..., xoxb-...)
@@ -148,31 +151,49 @@ class MessageOrchestrator:
             is_sync_bypass = handler.__name__ == "sync_threads"
             is_start_bypass = handler.__name__ in {"start_command", "agentic_start"}
             message_thread_id = self._extract_message_thread_id(update)
-            should_enforce = self.settings.enable_project_threads
+            chat = update.effective_chat
+            should_enforce_project_thread = self.settings.enable_project_threads
+            should_scope_thread_state = (
+                message_thread_id is not None and chat is not None
+            )
 
-            if should_enforce:
+            if should_enforce_project_thread:
                 if self.settings.project_threads_mode == "private":
-                    should_enforce = not is_sync_bypass and not (
+                    should_enforce_project_thread = not is_sync_bypass and not (
                         is_start_bypass and message_thread_id is None
                     )
                 else:
-                    should_enforce = not is_sync_bypass
+                    should_enforce_project_thread = not is_sync_bypass
 
-            if should_enforce:
-                allowed = await self._apply_thread_routing_context(update, context)
+            if should_enforce_project_thread:
+                allowed = await self._apply_thread_routing_context(
+                    update,
+                    context,
+                    message_thread_id,
+                )
                 if not allowed:
                     return
+            elif should_scope_thread_state:
+                self._load_thread_state(
+                    context,
+                    chat_id=chat.id,
+                    message_thread_id=message_thread_id,
+                    project_root=self.settings.approved_directory,
+                )
 
             try:
                 await handler(update, context)
             finally:
-                if should_enforce:
+                if should_enforce_project_thread or should_scope_thread_state:
                     self._persist_thread_state(context)
 
         return wrapped
 
     async def _apply_thread_routing_context(
-        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+        message_thread_id: Optional[int],
     ) -> bool:
         """Enforce strict project-thread routing and load thread-local state."""
         manager = context.bot_data.get("project_threads_manager")
@@ -204,7 +225,6 @@ class MessageOrchestrator:
                 )
                 return False
 
-        message_thread_id = self._extract_message_thread_id(update)
         if not message_thread_id:
             await self._reject_for_thread_mode(
                 update,
@@ -220,11 +240,32 @@ class MessageOrchestrator:
             )
             return False
 
-        state_key = f"{chat.id}:{message_thread_id}"
+        self._load_thread_state(
+            context,
+            chat_id=chat.id,
+            message_thread_id=message_thread_id,
+            project_root=project.absolute_path,
+            project_slug=project.slug,
+            project_name=project.name,
+        )
+        return True
+
+    def _load_thread_state(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        *,
+        chat_id: int,
+        message_thread_id: int,
+        project_root: Path,
+        project_slug: Optional[str] = None,
+        project_name: Optional[str] = None,
+    ) -> None:
+        """Load thread-local compatibility keys into user_data."""
+        state_key = f"{chat_id}:{message_thread_id}"
         thread_states = context.user_data.setdefault("thread_state", {})
         state = thread_states.get(state_key, {})
 
-        project_root = project.absolute_path
+        project_root = project_root.resolve()
         current_dir_raw = state.get("current_directory")
         current_dir = (
             Path(current_dir_raw).resolve() if current_dir_raw else project_root
@@ -234,15 +275,19 @@ class MessageOrchestrator:
 
         context.user_data["current_directory"] = current_dir
         context.user_data["claude_session_id"] = state.get("claude_session_id")
+        for key in _THREAD_SCOPED_SESSION_KEYS:
+            if key in state:
+                context.user_data[key] = state[key]
+            else:
+                context.user_data.pop(key, None)
         context.user_data["_thread_context"] = {
-            "chat_id": chat.id,
+            "chat_id": chat_id,
             "message_thread_id": message_thread_id,
             "state_key": state_key,
-            "project_slug": project.slug,
+            "project_slug": project_slug,
             "project_root": str(project_root),
-            "project_name": project.name,
+            "project_name": project_name,
         }
-        return True
 
     def _persist_thread_state(self, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Persist compatibility keys back into per-thread state."""
@@ -258,12 +303,17 @@ class MessageOrchestrator:
         if not self._is_within(current_dir, project_root) or not current_dir.is_dir():
             current_dir = project_root
 
-        thread_states = context.user_data.setdefault("thread_state", {})
-        thread_states[thread_context["state_key"]] = {
+        thread_state = {
             "current_directory": str(current_dir),
             "claude_session_id": context.user_data.get("claude_session_id"),
             "project_slug": thread_context["project_slug"],
         }
+        for key in _THREAD_SCOPED_SESSION_KEYS:
+            if key in context.user_data:
+                thread_state[key] = context.user_data[key]
+
+        thread_states = context.user_data.setdefault("thread_state", {})
+        thread_states[thread_context["state_key"]] = thread_state
 
     @staticmethod
     def _is_within(path: Path, root: Path) -> bool:
@@ -972,6 +1022,25 @@ class MessageOrchestrator:
         # Check if /new was used — skip auto-resume for this first message.
         # Flag is only cleared after a successful run so retries keep the intent.
         force_new = bool(context.user_data.get("force_new_session"))
+
+        # Thread-scoped topics must not fall back to ClaudeIntegration's
+        # user+directory auto-resume. A brand-new Telegram topic has no
+        # claude_session_id yet, but shares the same working directory with other
+        # topics; without this guard, run_command() resumes the latest global
+        # session for the user and leaks context across topics.
+        if context.user_data.get("_thread_context") and not session_id:
+            force_new = True
+
+        thread_context = context.user_data.get("_thread_context")
+        if thread_context:
+            logger.info(
+                "Thread-scoped Claude routing",
+                chat_id=thread_context.get("chat_id"),
+                message_thread_id=thread_context.get("message_thread_id"),
+                state_key=thread_context.get("state_key"),
+                session_id=session_id,
+                force_new=force_new,
+            )
 
         # --- Verbose progress tracking via stream callback ---
         tool_log: List[Dict[str, Any]] = []

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -345,7 +345,10 @@ class ClaudeSDKManager:
                     "excludedCommands": self.config.sandbox_excluded_commands or [],
                 },
                 system_prompt=base_prompt,
-                setting_sources=["project"],
+                # ["user", "project"] loads ~/.claude/* (skills, plugins, MCP
+                # servers, settings.json) AND project-local .claude/. Default
+                # of upstream is ["project"] which decapitates the agent.
+                setting_sources=["user", "project"],
                 stderr=_stderr_callback,
             )
 

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -296,16 +296,25 @@ class ClaudeSDKManager:
                 stderr_lines.append(line)
                 logger.debug("Claude CLI stderr", line=line)
 
-            # Build system prompt, loading CLAUDE.md from working directory if present
+            # Build system prompt, loading global + project CLAUDE.md if present.
+            # Global identity (~/.claude/CLAUDE.md) ensures the bundled Claude
+            # knows it's running inside a Telegram bot daemon and not in ACP.
             base_prompt = (
                 f"All file operations must stay within {working_directory}. "
                 "Use relative paths."
             )
+            global_claude_md = Path.home() / ".claude" / "CLAUDE.md"
+            if global_claude_md.exists():
+                base_prompt += "\n\n" + global_claude_md.read_text(encoding="utf-8")
+                logger.info(
+                    "Loaded global CLAUDE.md into system prompt",
+                    path=str(global_claude_md),
+                )
             claude_md_path = Path(working_directory) / "CLAUDE.md"
             if claude_md_path.exists():
                 base_prompt += "\n\n" + claude_md_path.read_text(encoding="utf-8")
                 logger.info(
-                    "Loaded CLAUDE.md into system prompt",
+                    "Loaded project CLAUDE.md into system prompt",
                     path=str(claude_md_path),
                 )
 

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -309,14 +309,16 @@ class ClaudeSDKManager:
                     path=str(claude_md_path),
                 )
 
-            # When DISABLE_TOOL_VALIDATION=true, pass None for allowed/disallowed
-            # tools so the SDK does not restrict tool usage (e.g. MCP tools).
+            # When DISABLE_TOOL_VALIDATION=true, pass [] for allowed/disallowed
+            # tools. Empty lists make the SDK omit --allowedTools/--disallowedTools
+            # flags entirely (CLI defaults apply). None would crash the SDK at
+            # _apply_skills_defaults: list(None) -> TypeError.
             if self.config.disable_tool_validation:
-                sdk_allowed_tools = None
-                sdk_disallowed_tools = None
+                sdk_allowed_tools = []
+                sdk_disallowed_tools = []
             else:
-                sdk_allowed_tools = self.config.claude_allowed_tools
-                sdk_disallowed_tools = self.config.claude_disallowed_tools
+                sdk_allowed_tools = self.config.claude_allowed_tools or []
+                sdk_disallowed_tools = self.config.claude_disallowed_tools or []
 
             # Build Claude Agent options
             options = ClaudeAgentOptions(

--- a/tests/unit/test_bot/test_orchestrator_thread_context.py
+++ b/tests/unit/test_bot/test_orchestrator_thread_context.py
@@ -1,0 +1,390 @@
+"""Focused tests for orchestrator project-thread context isolation."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.bot.orchestrator import MessageOrchestrator
+from src.config import create_test_config
+
+
+@pytest.fixture
+def group_thread_settings(tmp_path: Path):
+    project_root = tmp_path / "project_a"
+    project_root.mkdir()
+    (project_root / "topic101").mkdir()
+
+    config_file = tmp_path / "projects.yaml"
+    config_file.write_text(
+        "projects:\n"
+        "  - slug: project_a\n"
+        "    name: Project A\n"
+        "    path: project_a\n",
+        encoding="utf-8",
+    )
+
+    return create_test_config(
+        approved_directory=str(tmp_path),
+        agentic_mode=True,
+        enable_project_threads=True,
+        project_threads_mode="group",
+        project_threads_chat_id=-1001234567890,
+        projects_config_path=str(config_file),
+    )
+
+
+@pytest.fixture
+def disabled_thread_settings(tmp_path: Path):
+    return create_test_config(
+        approved_directory=str(tmp_path),
+        agentic_mode=True,
+        enable_project_threads=False,
+    )
+
+
+@pytest.fixture
+def deps():
+    return {
+        "claude_integration": MagicMock(),
+        "storage": MagicMock(),
+        "security_validator": MagicMock(),
+        "rate_limiter": MagicMock(),
+        "audit_logger": MagicMock(),
+    }
+
+
+@pytest.fixture
+def project(group_thread_settings):
+    return SimpleNamespace(
+        slug="project_a",
+        name="Project A",
+        absolute_path=group_thread_settings.approved_directory / "project_a",
+    )
+
+
+def _manager_for(project):
+    manager = MagicMock()
+    manager.resolve_project = AsyncMock(return_value=project)
+    manager.guidance_message.return_value = "Use project thread"
+    return manager
+
+
+def _context(initial_user_data=None):
+    context = MagicMock()
+    context.bot_data = {}
+    context.user_data = initial_user_data or {}
+    return context
+
+
+def _forum_update(thread_id: int | None):
+    message = MagicMock()
+    message.message_thread_id = thread_id
+    message.direct_messages_topic = None
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_chat.id = -1001234567890
+    update.effective_chat.is_forum = True
+    update.effective_message = message
+    update.message = message
+    update.callback_query = None
+    return update
+
+
+def _private_update_without_thread():
+    message = MagicMock()
+    message.message_thread_id = None
+    message.direct_messages_topic = None
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_chat.id = 12345
+    update.effective_chat.is_forum = False
+    update.effective_chat.type = "private"
+    update.effective_message = message
+    update.message = message
+    update.callback_query = None
+    return update
+
+
+def _direct_message_topic_update(topic_id: int):
+    message = MagicMock()
+    message.message_thread_id = None
+    message.direct_messages_topic = SimpleNamespace(topic_id=topic_id)
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_chat.id = 12345
+    update.effective_chat.is_forum = False
+    update.effective_chat.type = "private"
+    update.effective_message = message
+    update.message = message
+    update.callback_query = None
+    return update
+
+
+async def test_topics_keep_current_directory_and_session_isolated(
+    group_thread_settings, deps, project
+):
+    """Topic 202 in the same chat must not inherit topic 101 state."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+    manager = _manager_for(project)
+    deps["project_threads_manager"] = manager
+    context = _context()
+    topic_101_dir = project.absolute_path / "topic101"
+
+    async def topic_101_handler(update, context):
+        assert context.user_data["current_directory"] == project.absolute_path
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["current_directory"] = topic_101_dir
+        context.user_data["claude_session_id"] = "topic-101-session"
+
+    await orchestrator._inject_deps(topic_101_handler)(
+        _forum_update(101),
+        context,
+    )
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["current_directory"] == project.absolute_path
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["claude_session_id"] = "topic-202-session"
+
+    await orchestrator._inject_deps(topic_202_handler)(
+        _forum_update(202),
+        context,
+    )
+
+    thread_state = context.user_data["thread_state"]
+    assert thread_state["-1001234567890:101"]["current_directory"] == str(topic_101_dir)
+    assert thread_state["-1001234567890:101"]["claude_session_id"] == (
+        "topic-101-session"
+    )
+    assert thread_state["-1001234567890:202"]["current_directory"] == str(
+        project.absolute_path
+    )
+    assert thread_state["-1001234567890:202"]["claude_session_id"] == (
+        "topic-202-session"
+    )
+
+
+async def test_general_forum_topic_without_message_thread_id_uses_thread_one(
+    group_thread_settings, deps, project
+):
+    """Telegram omits message_thread_id for General; wrapper must route it as 1."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+    manager = _manager_for(project)
+    deps["project_threads_manager"] = manager
+    context = _context()
+
+    async def handler(update, context):
+        assert context.user_data["_thread_context"]["message_thread_id"] == 1
+        context.user_data["claude_session_id"] = "general-session"
+
+    await orchestrator._inject_deps(handler)(_forum_update(None), context)
+
+    manager.resolve_project.assert_awaited_once_with(-1001234567890, 1)
+    assert (
+        context.user_data["thread_state"]["-1001234567890:1"]["claude_session_id"]
+        == "general-session"
+    )
+
+
+async def test_disabled_project_threads_still_isolate_forum_topic_state(
+    disabled_thread_settings, deps
+):
+    """ENABLE_PROJECT_THREADS=false scopes sessions by forum topic without manager."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    manager = MagicMock()
+    manager.resolve_project = AsyncMock()
+    deps["project_threads_manager"] = manager
+    context = _context()
+    topic_101_dir = disabled_thread_settings.approved_directory / "topic101"
+    topic_101_dir.mkdir()
+
+    async def topic_101_handler(update, context):
+        assert context.user_data["current_directory"] == (
+            disabled_thread_settings.approved_directory
+        )
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["current_directory"] = topic_101_dir
+        context.user_data["claude_session_id"] = "topic-101-session"
+
+    await orchestrator._inject_deps(topic_101_handler)(_forum_update(101), context)
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["current_directory"] == (
+            disabled_thread_settings.approved_directory
+        )
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["claude_session_id"] = "topic-202-session"
+
+    await orchestrator._inject_deps(topic_202_handler)(_forum_update(202), context)
+
+    thread_state = context.user_data["thread_state"]
+    manager.resolve_project.assert_not_called()
+    assert thread_state["-1001234567890:101"]["current_directory"] == str(topic_101_dir)
+    assert thread_state["-1001234567890:101"]["claude_session_id"] == (
+        "topic-101-session"
+    )
+    assert thread_state["-1001234567890:202"]["current_directory"] == str(
+        disabled_thread_settings.approved_directory
+    )
+    assert thread_state["-1001234567890:202"]["claude_session_id"] == (
+        "topic-202-session"
+    )
+
+
+async def test_disabled_project_threads_new_command_is_topic_local(
+    disabled_thread_settings, deps
+):
+    """/new with generic topic scoping must not leak force_new_session."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    context = _context(
+        {
+            "thread_state": {
+                "-1001234567890:101": {
+                    "current_directory": str(
+                        disabled_thread_settings.approved_directory
+                    ),
+                    "claude_session_id": "topic-101-old",
+                },
+                "-1001234567890:202": {
+                    "current_directory": str(
+                        disabled_thread_settings.approved_directory
+                    ),
+                    "claude_session_id": "topic-202-old",
+                },
+            }
+        }
+    )
+
+    await orchestrator._inject_deps(orchestrator.agentic_new)(
+        _forum_update(101),
+        context,
+    )
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["claude_session_id"]
+        is None
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["force_new_session"]
+        is True
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["session_started"]
+        is True
+    )
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["claude_session_id"] == "topic-202-old"
+        assert context.user_data.get("force_new_session") is not True
+        assert context.user_data.get("session_started") is not True
+
+    await orchestrator._inject_deps(topic_202_handler)(_forum_update(202), context)
+
+    assert (
+        "force_new_session"
+        not in context.user_data["thread_state"]["-1001234567890:202"]
+    )
+    assert (
+        "session_started" not in context.user_data["thread_state"]["-1001234567890:202"]
+    )
+
+
+async def test_private_chat_without_thread_keeps_unscoped_behavior(
+    disabled_thread_settings, deps
+):
+    """Plain private chats do not create generic thread context."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    context = _context()
+
+    async def handler(update, context):
+        context.user_data["claude_session_id"] = "private-session"
+
+    await orchestrator._inject_deps(handler)(_private_update_without_thread(), context)
+
+    assert "_thread_context" not in context.user_data
+    assert "thread_state" not in context.user_data
+
+
+async def test_direct_message_topic_uses_generic_thread_state(
+    disabled_thread_settings, deps
+):
+    """Direct-message topics with topic_id get the same generic isolation."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    context = _context()
+
+    async def handler(update, context):
+        assert context.user_data["_thread_context"]["state_key"] == "12345:909"
+        context.user_data["claude_session_id"] = "dm-topic-session"
+
+    await orchestrator._inject_deps(handler)(
+        _direct_message_topic_update(909),
+        context,
+    )
+
+    assert context.user_data["thread_state"]["12345:909"]["claude_session_id"] == (
+        "dm-topic-session"
+    )
+
+
+async def test_agentic_new_session_flags_are_topic_local(
+    group_thread_settings, deps, project
+):
+    """/new state is persisted only for the current forum topic."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+    manager = _manager_for(project)
+    deps["project_threads_manager"] = manager
+    context = _context(
+        {
+            "thread_state": {
+                "-1001234567890:101": {
+                    "current_directory": str(project.absolute_path),
+                    "claude_session_id": "topic-101-old",
+                },
+                "-1001234567890:202": {
+                    "current_directory": str(project.absolute_path),
+                    "claude_session_id": "topic-202-old",
+                },
+            }
+        }
+    )
+
+    await orchestrator._inject_deps(orchestrator.agentic_new)(
+        _forum_update(101),
+        context,
+    )
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["claude_session_id"]
+        is None
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["force_new_session"]
+        is True
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["session_started"]
+        is True
+    )
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["claude_session_id"] == "topic-202-old"
+        assert context.user_data.get("force_new_session") is not True
+        assert context.user_data.get("session_started") is not True
+
+    await orchestrator._inject_deps(topic_202_handler)(
+        _forum_update(202),
+        context,
+    )
+
+    assert (
+        "force_new_session"
+        not in context.user_data["thread_state"]["-1001234567890:202"]
+    )
+    assert (
+        "session_started" not in context.user_data["thread_state"]["-1001234567890:202"]
+    )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -322,6 +322,60 @@ async def test_agentic_text_calls_claude(agentic_settings, deps):
         assert call.kwargs.get("reply_markup") is None
 
 
+async def test_agentic_text_forces_new_session_for_new_thread_context(
+    agentic_settings, deps
+):
+    """A new Telegram topic must not auto-resume the user's latest cwd session."""
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+    mock_response = MagicMock()
+    mock_response.session_id = "topic-session-abc"
+    mock_response.content = "Fresh topic response"
+    mock_response.tools_used = []
+
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(return_value=mock_response)
+
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.message.text = "What word did I give you?"
+    update.message.message_id = 1
+    update.message.chat.send_action = AsyncMock()
+    update.message.reply_text = AsyncMock()
+
+    progress_msg = AsyncMock()
+    progress_msg.delete = AsyncMock()
+    update.message.reply_text.return_value = progress_msg
+
+    context = MagicMock()
+    context.user_data = {
+        "current_directory": agentic_settings.approved_directory,
+        "claude_session_id": None,
+        "_thread_context": {
+            "chat_id": -1001234567890,
+            "message_thread_id": 202,
+            "state_key": "-1001234567890:202",
+            "project_root": str(agentic_settings.approved_directory),
+            "project_slug": None,
+            "project_name": None,
+        },
+    }
+    context.bot_data = {
+        "settings": agentic_settings,
+        "claude_integration": claude_integration,
+        "storage": None,
+        "rate_limiter": None,
+        "audit_logger": None,
+    }
+
+    await orchestrator.agentic_text(update, context)
+
+    claude_integration.run_command.assert_called_once()
+    assert claude_integration.run_command.call_args.kwargs["session_id"] is None
+    assert claude_integration.run_command.call_args.kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "topic-session-abc"
+
+
 async def test_agentic_callback_scoped_to_cd_pattern(agentic_settings, deps):
     """Agentic callback handler is registered with cd: pattern filter."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
@@ -789,6 +843,88 @@ async def test_thread_mode_loads_and_persists_thread_state(group_thread_settings
     assert (
         context.user_data["thread_state"]["-1001234567890:777"]["claude_session_id"]
         == "new-session"
+    )
+
+
+async def test_thread_mode_new_session_flag_is_isolated_per_topic(
+    group_thread_settings, deps
+):
+    """/new in one forum topic must not force a new Claude session in another."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+
+    project_path = group_thread_settings.approved_directory / "project_a"
+    project = SimpleNamespace(
+        slug="project_a",
+        name="Project A",
+        absolute_path=project_path,
+    )
+
+    project_threads_manager = MagicMock()
+    project_threads_manager.resolve_project = AsyncMock(return_value=project)
+    project_threads_manager.guidance_message.return_value = "Use project thread"
+    deps["project_threads_manager"] = project_threads_manager
+
+    context = MagicMock()
+    context.bot_data = {}
+    context.user_data = {
+        "thread_state": {
+            "-1001234567890:777": {
+                "current_directory": str(project_path),
+                "claude_session_id": "topic-777-session",
+            },
+            "-1001234567890:888": {
+                "current_directory": str(project_path),
+                "claude_session_id": "topic-888-session",
+            },
+        }
+    }
+
+    message_777 = MagicMock()
+    message_777.message_thread_id = 777
+    message_777.reply_text = AsyncMock()
+    update_777 = MagicMock()
+    update_777.effective_chat.id = -1001234567890
+    update_777.effective_chat.is_forum = True
+    update_777.effective_message = message_777
+    update_777.message = message_777
+    update_777.callback_query = None
+
+    wrapped_new = orchestrator._inject_deps(orchestrator.agentic_new)
+    await wrapped_new(update_777, context)
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:777"]["claude_session_id"]
+        is None
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:777"]["force_new_session"]
+        is True
+    )
+
+    message_888 = MagicMock()
+    message_888.message_thread_id = 888
+    message_888.reply_text = AsyncMock()
+    update_888 = MagicMock()
+    update_888.effective_chat.id = -1001234567890
+    update_888.effective_chat.is_forum = True
+    update_888.effective_message = message_888
+    update_888.message = message_888
+    update_888.callback_query = None
+
+    async def assert_topic_888_context(update, context):
+        assert context.user_data["claude_session_id"] == "topic-888-session"
+        assert not context.user_data.get("force_new_session", False)
+        context.user_data["claude_session_id"] = "topic-888-next-session"
+
+    await orchestrator._inject_deps(assert_topic_888_context)(update_888, context)
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:888"]["claude_session_id"]
+        == "topic-888-next-session"
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:777"]["force_new_session"]
+        is True
     )
 
 


### PR DESCRIPTION
## Summary
- scope Telegram forum topic state by `chat_id:message_thread_id`
- prevent new topics from auto-resuming another topic's Claude session
- keep `/new` / session flags local to the active topic
- add regression coverage for generic forum topic isolation, General topic handling, DM topics, and Claude `force_new` routing

## Test plan
- `uv run --with black black --check src/bot/orchestrator.py tests/unit/test_orchestrator.py tests/unit/test_bot/test_orchestrator_thread_context.py`
- `uv run pytest tests/unit/test_orchestrator.py::test_agentic_text_forces_new_session_for_new_thread_context tests/unit/test_bot/test_orchestrator_thread_context.py -q`
- `uv run pytest tests/unit/test_bot -q`
- `git diff --check`

## Notes
This fixes a context leak where a brand-new Telegram topic had no `claude_session_id`, causing the Claude integration to auto-resume the latest session for the same user and working directory.
