### PR TITLE
fix: isolate Claude sessions by Telegram topic

### DIFF
--- a/src/bot/handlers/callback.py
+++ b/src/bot/handlers/callback.py
@@ -165,11 +165,16 @@ async def handle_cd_callback(
             )
             return
 
-        # Update directory and resume session for that directory when available
+        # Update directory and resume session for that directory when available.
+        # In Telegram forum topics, never import a global user+directory session
+        # from another topic.
         context.user_data["current_directory"] = new_path
 
         resumed_session_info = ""
-        if claude_integration:
+        if context.user_data.get("_thread_context"):
+            context.user_data["claude_session_id"] = None
+            resumed_session_info = "\n🆕 Topic-scoped directory change. Send a message to start a new session."
+        elif claude_integration:
             existing_session = await claude_integration._find_resumable_session(
                 user_id, new_path
             )
@@ -567,6 +572,28 @@ async def _handle_continue_action(query, context: ContextTypes.DEFAULT_TYPE) -> 
                 session_id=claude_session_id,
             )
         else:
+            if context.user_data.get("_thread_context"):
+                await query.edit_message_text(
+                    "❌ <b>No Topic Session Found</b>\n\n"
+                    f"No Claude session has been started in this Telegram topic yet.\n"
+                    f"Directory: <code>{escape_html(str(current_dir.relative_to(settings.approved_directory)))}/</code>\n\n"
+                    f"Send a message in this topic or use the button below to start fresh.",
+                    parse_mode="HTML",
+                    reply_markup=InlineKeyboardMarkup(
+                        [
+                            [
+                                InlineKeyboardButton(
+                                    "🆕 New Session", callback_data="action:new_session"
+                                ),
+                                InlineKeyboardButton(
+                                    "📊 Status", callback_data="action:status"
+                                ),
+                            ]
+                        ]
+                    ),
+                )
+                return
+
             # No session in context, try to find the most recent session
             await query.edit_message_text(
                 "🔍 <b>Looking for Recent Session</b>\n\n"
@@ -918,12 +945,21 @@ async def handle_quick_action_callback(
             parse_mode="HTML",
         )
 
+        session_id = context.user_data.get("claude_session_id")
+        force_new = bool(context.user_data.get("_thread_context") and not session_id)
+
         # Run the action through Claude
         claude_response = await claude_integration.run_command(
-            prompt=action.prompt, working_directory=current_dir, user_id=user_id
+            prompt=action.prompt,
+            working_directory=current_dir,
+            user_id=user_id,
+            session_id=session_id,
+            force_new=force_new,
         )
 
         if claude_response:
+            context.user_data["claude_session_id"] = claude_response.session_id
+
             # Format and send the response
             response_text = escape_html(claude_response.content)
             if len(response_text) > 4000:

--- a/src/bot/handlers/callback.py
+++ b/src/bot/handlers/callback.py
@@ -12,6 +12,7 @@ from ...config.settings import Settings
 from ...security.audit import AuditLogger
 from ...security.validators import SecurityValidator
 from ..utils.html_format import escape_html
+from .message import _should_force_new_claude_session
 
 logger = structlog.get_logger()
 
@@ -946,7 +947,7 @@ async def handle_quick_action_callback(
         )
 
         session_id = context.user_data.get("claude_session_id")
-        force_new = bool(context.user_data.get("_thread_context") and not session_id)
+        force_new = _should_force_new_claude_session(context, session_id)
 
         # Run the action through Claude
         claude_response = await claude_integration.run_command(
@@ -956,6 +957,9 @@ async def handle_quick_action_callback(
             session_id=session_id,
             force_new=force_new,
         )
+
+        if force_new:
+            context.user_data["force_new_session"] = False
 
         if claude_response:
             context.user_data["claude_session_id"] = claude_response.session_id

--- a/src/bot/handlers/command.py
+++ b/src/bot/handlers/command.py
@@ -905,7 +905,7 @@ async def session_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
     # Check if there's a resumable session from the database
     resumable_info = ""
-    if not claude_session_id:
+    if not claude_session_id and not context.user_data.get("_thread_context"):
         claude_integration: ClaudeIntegration = context.bot_data.get(
             "claude_integration"
         )

--- a/src/bot/handlers/command.py
+++ b/src/bot/handlers/command.py
@@ -403,19 +403,29 @@ async def continue_session(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 session_id=claude_session_id,
             )
         else:
-            # No session in context, try to find the most recent session
-            status_msg = await update.message.reply_text(
-                "🔍 <b>Looking for Recent Session</b>\n\n"
-                "Searching for your most recent session in this directory...",
-                parse_mode="HTML",
-            )
+            if context.user_data.get("_thread_context"):
+                status_msg = await update.message.reply_text(
+                    "❌ <b>No Topic Session Found</b>\n\n"
+                    f"No Claude session has been started in this Telegram topic yet.\n"
+                    f"Directory: <code>{current_dir.relative_to(settings.approved_directory)}/</code>\n\n"
+                    f"Send a message in this topic or use <code>/new</code> to start fresh.",
+                    parse_mode="HTML",
+                )
+                claude_response = None
+            else:
+                # No session in context, try to find the most recent session
+                status_msg = await update.message.reply_text(
+                    "🔍 <b>Looking for Recent Session</b>\n\n"
+                    "Searching for your most recent session in this directory...",
+                    parse_mode="HTML",
+                )
 
-            # Use default prompt if none provided
-            claude_response = await claude_integration.continue_session(
-                user_id=user_id,
-                working_directory=current_dir,
-                prompt=prompt or default_prompt,
-            )
+                # Use default prompt if none provided
+                claude_response = await claude_integration.continue_session(
+                    user_id=user_id,
+                    working_directory=current_dir,
+                    prompt=prompt or default_prompt,
+                )
 
         if claude_response:
             # Update session ID in context

--- a/src/bot/handlers/command.py
+++ b/src/bot/handlers/command.py
@@ -687,12 +687,17 @@ async def change_directory(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         # Update current directory in user data
         context.user_data["current_directory"] = resolved_path
 
-        # Look up existing session for the new directory instead of clearing
+        # Look up existing session for the new directory in non-thread contexts
+        # only. Telegram forum topics must not import global user+directory
+        # sessions from other topics.
         claude_integration: ClaudeIntegration = context.bot_data.get(
             "claude_integration"
         )
         resumed_session_info = ""
-        if claude_integration:
+        if context.user_data.get("_thread_context"):
+            context.user_data["claude_session_id"] = None
+            resumed_session_info = "\n🆕 Topic-scoped directory change. Send a message to start a new session."
+        elif claude_integration:
             existing_session = await claude_integration._find_resumable_session(
                 user_id, resolved_path
             )

--- a/src/bot/handlers/message.py
+++ b/src/bot/handlers/message.py
@@ -29,6 +29,15 @@ from ..utils.image_extractor import (
 logger = structlog.get_logger()
 
 
+def _should_force_new_claude_session(
+    context: ContextTypes.DEFAULT_TYPE, session_id: Optional[str]
+) -> bool:
+    """Prevent thread-scoped contexts from falling back to global auto-resume."""
+    if context.user_data.get("force_new_session"):
+        return True
+    return bool(context.user_data.get("_thread_context") and not session_id)
+
+
 async def _format_progress_update(update_obj) -> Optional[str]:
     """Format progress updates with enhanced context and visual indicators."""
     if update_obj.type == "tool_result":
@@ -351,9 +360,7 @@ async def handle_text_message(
         # Get existing session ID
         session_id = context.user_data.get("claude_session_id")
 
-        # Check if /new was used — skip auto-resume for this first message.
-        # Flag is only cleared after a successful run so retries keep the intent.
-        force_new = bool(context.user_data.get("force_new_session"))
+        force_new = _should_force_new_claude_session(context, session_id)
 
         # MCP image collection via stream intercept
         mcp_images: list[ImageAttachment] = []
@@ -810,6 +817,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             "current_directory", settings.approved_directory
         )
         session_id = context.user_data.get("claude_session_id")
+        force_new = _should_force_new_claude_session(context, session_id)
 
         # Process with Claude
         try:
@@ -818,7 +826,11 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 working_directory=current_dir,
                 user_id=user_id,
                 session_id=session_id,
+                force_new=force_new,
             )
+
+            if force_new:
+                context.user_data["force_new_session"] = False
 
             # Update session ID
             context.user_data["claude_session_id"] = claude_response.session_id
@@ -937,6 +949,7 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 "current_directory", settings.approved_directory
             )
             session_id = context.user_data.get("claude_session_id")
+            force_new = _should_force_new_claude_session(context, session_id)
 
             # Process with Claude
             try:
@@ -945,7 +958,11 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     working_directory=current_dir,
                     user_id=user_id,
                     session_id=session_id,
+                    force_new=force_new,
                 )
+
+                if force_new:
+                    context.user_data["force_new_session"] = False
 
                 # Update session ID
                 context.user_data["claude_session_id"] = claude_response.session_id
@@ -1064,6 +1081,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             "current_directory", settings.approved_directory
         )
         session_id = context.user_data.get("claude_session_id")
+        force_new = _should_force_new_claude_session(context, session_id)
 
         try:
             # Keep classic mode aligned with handle_photo: single progress message,
@@ -1073,7 +1091,11 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 working_directory=current_dir,
                 user_id=user_id,
                 session_id=session_id,
+                force_new=force_new,
             )
+
+            if force_new:
+                context.user_data["force_new_session"] = False
 
             context.user_data["claude_session_id"] = claude_response.session_id
 

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -49,6 +49,9 @@ _MEDIA_TYPE_MAP = {
     "webp": "image/webp",
 }
 
+# Session-control flags must be scoped to each Telegram forum topic, not user-wide.
+_THREAD_SCOPED_SESSION_KEYS = ("force_new_session", "session_started")
+
 # Patterns that look like secrets/credentials in CLI arguments
 _SECRET_PATTERNS: List[re.Pattern[str]] = [
     # API keys / tokens (sk-ant-..., sk-..., ghp_..., gho_..., github_pat_..., xoxb-...)
@@ -148,31 +151,49 @@ class MessageOrchestrator:
             is_sync_bypass = handler.__name__ == "sync_threads"
             is_start_bypass = handler.__name__ in {"start_command", "agentic_start"}
             message_thread_id = self._extract_message_thread_id(update)
-            should_enforce = self.settings.enable_project_threads
+            chat = update.effective_chat
+            should_enforce_project_thread = self.settings.enable_project_threads
+            should_scope_thread_state = (
+                message_thread_id is not None and chat is not None
+            )
 
-            if should_enforce:
+            if should_enforce_project_thread:
                 if self.settings.project_threads_mode == "private":
-                    should_enforce = not is_sync_bypass and not (
+                    should_enforce_project_thread = not is_sync_bypass and not (
                         is_start_bypass and message_thread_id is None
                     )
                 else:
-                    should_enforce = not is_sync_bypass
+                    should_enforce_project_thread = not is_sync_bypass
 
-            if should_enforce:
-                allowed = await self._apply_thread_routing_context(update, context)
+            if should_enforce_project_thread:
+                allowed = await self._apply_thread_routing_context(
+                    update,
+                    context,
+                    message_thread_id,
+                )
                 if not allowed:
                     return
+            elif should_scope_thread_state:
+                self._load_thread_state(
+                    context,
+                    chat_id=chat.id,
+                    message_thread_id=message_thread_id,
+                    project_root=self.settings.approved_directory,
+                )
 
             try:
                 await handler(update, context)
             finally:
-                if should_enforce:
+                if should_enforce_project_thread or should_scope_thread_state:
                     self._persist_thread_state(context)
 
         return wrapped
 
     async def _apply_thread_routing_context(
-        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+        message_thread_id: Optional[int],
     ) -> bool:
         """Enforce strict project-thread routing and load thread-local state."""
         manager = context.bot_data.get("project_threads_manager")
@@ -204,7 +225,6 @@ class MessageOrchestrator:
                 )
                 return False
 
-        message_thread_id = self._extract_message_thread_id(update)
         if not message_thread_id:
             await self._reject_for_thread_mode(
                 update,
@@ -220,11 +240,32 @@ class MessageOrchestrator:
             )
             return False
 
-        state_key = f"{chat.id}:{message_thread_id}"
+        self._load_thread_state(
+            context,
+            chat_id=chat.id,
+            message_thread_id=message_thread_id,
+            project_root=project.absolute_path,
+            project_slug=project.slug,
+            project_name=project.name,
+        )
+        return True
+
+    def _load_thread_state(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        *,
+        chat_id: int,
+        message_thread_id: int,
+        project_root: Path,
+        project_slug: Optional[str] = None,
+        project_name: Optional[str] = None,
+    ) -> None:
+        """Load thread-local compatibility keys into user_data."""
+        state_key = f"{chat_id}:{message_thread_id}"
         thread_states = context.user_data.setdefault("thread_state", {})
         state = thread_states.get(state_key, {})
 
-        project_root = project.absolute_path
+        project_root = project_root.resolve()
         current_dir_raw = state.get("current_directory")
         current_dir = (
             Path(current_dir_raw).resolve() if current_dir_raw else project_root
@@ -234,15 +275,19 @@ class MessageOrchestrator:
 
         context.user_data["current_directory"] = current_dir
         context.user_data["claude_session_id"] = state.get("claude_session_id")
+        for key in _THREAD_SCOPED_SESSION_KEYS:
+            if key in state:
+                context.user_data[key] = state[key]
+            else:
+                context.user_data.pop(key, None)
         context.user_data["_thread_context"] = {
-            "chat_id": chat.id,
+            "chat_id": chat_id,
             "message_thread_id": message_thread_id,
             "state_key": state_key,
-            "project_slug": project.slug,
+            "project_slug": project_slug,
             "project_root": str(project_root),
-            "project_name": project.name,
+            "project_name": project_name,
         }
-        return True
 
     def _persist_thread_state(self, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Persist compatibility keys back into per-thread state."""
@@ -258,12 +303,17 @@ class MessageOrchestrator:
         if not self._is_within(current_dir, project_root) or not current_dir.is_dir():
             current_dir = project_root
 
-        thread_states = context.user_data.setdefault("thread_state", {})
-        thread_states[thread_context["state_key"]] = {
+        thread_state = {
             "current_directory": str(current_dir),
             "claude_session_id": context.user_data.get("claude_session_id"),
             "project_slug": thread_context["project_slug"],
         }
+        for key in _THREAD_SCOPED_SESSION_KEYS:
+            if key in context.user_data:
+                thread_state[key] = context.user_data[key]
+
+        thread_states = context.user_data.setdefault("thread_state", {})
+        thread_states[thread_context["state_key"]] = thread_state
 
     @staticmethod
     def _is_within(path: Path, root: Path) -> bool:
@@ -972,6 +1022,25 @@ class MessageOrchestrator:
         # Check if /new was used — skip auto-resume for this first message.
         # Flag is only cleared after a successful run so retries keep the intent.
         force_new = bool(context.user_data.get("force_new_session"))
+
+        # Thread-scoped topics must not fall back to ClaudeIntegration's
+        # user+directory auto-resume. A brand-new Telegram topic has no
+        # claude_session_id yet, but shares the same working directory with other
+        # topics; without this guard, run_command() resumes the latest global
+        # session for the user and leaks context across topics.
+        if context.user_data.get("_thread_context") and not session_id:
+            force_new = True
+
+        thread_context = context.user_data.get("_thread_context")
+        if thread_context:
+            logger.info(
+                "Thread-scoped Claude routing",
+                chat_id=thread_context.get("chat_id"),
+                message_thread_id=thread_context.get("message_thread_id"),
+                state_key=thread_context.get("state_key"),
+                session_id=session_id,
+                force_new=force_new,
+            )
 
         # --- Verbose progress tracking via stream callback ---
         tool_log: List[Dict[str, Any]] = []

--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -637,6 +637,21 @@ class MessageOrchestrator:
             return int(user_override)
         return self.settings.verbose_level
 
+    @staticmethod
+    def _should_force_new_claude_session(
+        context: ContextTypes.DEFAULT_TYPE, session_id: Optional[str]
+    ) -> bool:
+        """Decide whether Claude must skip auto-resume for this message.
+
+        Telegram forum topics are isolated by ``_thread_context``. A new topic
+        has no topic-local ``claude_session_id`` yet; in that case we must
+        force a fresh Claude session or ClaudeIntegration may auto-resume the
+        latest user+directory session from another topic.
+        """
+        if context.user_data.get("force_new_session"):
+            return True
+        return bool(context.user_data.get("_thread_context") and not session_id)
+
     async def agentic_verbose(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
     ) -> None:
@@ -1019,17 +1034,12 @@ class MessageOrchestrator:
         )
         session_id = context.user_data.get("claude_session_id")
 
-        # Check if /new was used — skip auto-resume for this first message.
-        # Flag is only cleared after a successful run so retries keep the intent.
-        force_new = bool(context.user_data.get("force_new_session"))
-
         # Thread-scoped topics must not fall back to ClaudeIntegration's
         # user+directory auto-resume. A brand-new Telegram topic has no
         # claude_session_id yet, but shares the same working directory with other
         # topics; without this guard, run_command() resumes the latest global
         # session for the user and leaks context across topics.
-        if context.user_data.get("_thread_context") and not session_id:
-            force_new = True
+        force_new = self._should_force_new_claude_session(context, session_id)
 
         thread_context = context.user_data.get("_thread_context")
         if thread_context:
@@ -1308,9 +1318,7 @@ class MessageOrchestrator:
         )
         session_id = context.user_data.get("claude_session_id")
 
-        # Check if /new was used — skip auto-resume for this first message.
-        # Flag is only cleared after a successful run so retries keep the intent.
-        force_new = bool(context.user_data.get("force_new_session"))
+        force_new = self._should_force_new_claude_session(context, session_id)
 
         verbose_level = self._get_verbose_level(context)
         tool_log: List[Dict[str, Any]] = []
@@ -1519,7 +1527,7 @@ class MessageOrchestrator:
             "current_directory", self.settings.approved_directory
         )
         session_id = context.user_data.get("claude_session_id")
-        force_new = bool(context.user_data.get("force_new_session"))
+        force_new = self._should_force_new_claude_session(context, session_id)
 
         verbose_level = self._get_verbose_level(context)
         tool_log: List[Dict[str, Any]] = []
@@ -1668,10 +1676,12 @@ class MessageOrchestrator:
 
             context.user_data["current_directory"] = target_path
 
-            # Try to find a resumable session
+            # Try to find a resumable session. In Telegram forum topics, session
+            # lookup must stay topic-local; falling back to user+directory here
+            # would reintroduce context leaks across topics.
             claude_integration = context.bot_data.get("claude_integration")
             session_id = None
-            if claude_integration:
+            if claude_integration and not context.user_data.get("_thread_context"):
                 existing = await claude_integration._find_resumable_session(
                     update.effective_user.id, target_path
                 )
@@ -1792,10 +1802,11 @@ class MessageOrchestrator:
 
         context.user_data["current_directory"] = new_path
 
-        # Look for a resumable session instead of always clearing
+        # Look for a resumable session in non-thread contexts only. Telegram
+        # forum topics must not fall back to the global user+directory session.
         claude_integration = context.bot_data.get("claude_integration")
         session_id = None
-        if claude_integration:
+        if claude_integration and not context.user_data.get("_thread_context"):
             existing = await claude_integration._find_resumable_session(
                 query.from_user.id, new_path
             )

--- a/tests/unit/test_bot/test_orchestrator_thread_context.py
+++ b/tests/unit/test_bot/test_orchestrator_thread_context.py
@@ -1,0 +1,390 @@
+"""Focused tests for orchestrator project-thread context isolation."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.bot.orchestrator import MessageOrchestrator
+from src.config import create_test_config
+
+
+@pytest.fixture
+def group_thread_settings(tmp_path: Path):
+    project_root = tmp_path / "project_a"
+    project_root.mkdir()
+    (project_root / "topic101").mkdir()
+
+    config_file = tmp_path / "projects.yaml"
+    config_file.write_text(
+        "projects:\n"
+        "  - slug: project_a\n"
+        "    name: Project A\n"
+        "    path: project_a\n",
+        encoding="utf-8",
+    )
+
+    return create_test_config(
+        approved_directory=str(tmp_path),
+        agentic_mode=True,
+        enable_project_threads=True,
+        project_threads_mode="group",
+        project_threads_chat_id=-1001234567890,
+        projects_config_path=str(config_file),
+    )
+
+
+@pytest.fixture
+def disabled_thread_settings(tmp_path: Path):
+    return create_test_config(
+        approved_directory=str(tmp_path),
+        agentic_mode=True,
+        enable_project_threads=False,
+    )
+
+
+@pytest.fixture
+def deps():
+    return {
+        "claude_integration": MagicMock(),
+        "storage": MagicMock(),
+        "security_validator": MagicMock(),
+        "rate_limiter": MagicMock(),
+        "audit_logger": MagicMock(),
+    }
+
+
+@pytest.fixture
+def project(group_thread_settings):
+    return SimpleNamespace(
+        slug="project_a",
+        name="Project A",
+        absolute_path=group_thread_settings.approved_directory / "project_a",
+    )
+
+
+def _manager_for(project):
+    manager = MagicMock()
+    manager.resolve_project = AsyncMock(return_value=project)
+    manager.guidance_message.return_value = "Use project thread"
+    return manager
+
+
+def _context(initial_user_data=None):
+    context = MagicMock()
+    context.bot_data = {}
+    context.user_data = initial_user_data or {}
+    return context
+
+
+def _forum_update(thread_id: int | None):
+    message = MagicMock()
+    message.message_thread_id = thread_id
+    message.direct_messages_topic = None
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_chat.id = -1001234567890
+    update.effective_chat.is_forum = True
+    update.effective_message = message
+    update.message = message
+    update.callback_query = None
+    return update
+
+
+def _private_update_without_thread():
+    message = MagicMock()
+    message.message_thread_id = None
+    message.direct_messages_topic = None
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_chat.id = 12345
+    update.effective_chat.is_forum = False
+    update.effective_chat.type = "private"
+    update.effective_message = message
+    update.message = message
+    update.callback_query = None
+    return update
+
+
+def _direct_message_topic_update(topic_id: int):
+    message = MagicMock()
+    message.message_thread_id = None
+    message.direct_messages_topic = SimpleNamespace(topic_id=topic_id)
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_chat.id = 12345
+    update.effective_chat.is_forum = False
+    update.effective_chat.type = "private"
+    update.effective_message = message
+    update.message = message
+    update.callback_query = None
+    return update
+
+
+async def test_topics_keep_current_directory_and_session_isolated(
+    group_thread_settings, deps, project
+):
+    """Topic 202 in the same chat must not inherit topic 101 state."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+    manager = _manager_for(project)
+    deps["project_threads_manager"] = manager
+    context = _context()
+    topic_101_dir = project.absolute_path / "topic101"
+
+    async def topic_101_handler(update, context):
+        assert context.user_data["current_directory"] == project.absolute_path
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["current_directory"] = topic_101_dir
+        context.user_data["claude_session_id"] = "topic-101-session"
+
+    await orchestrator._inject_deps(topic_101_handler)(
+        _forum_update(101),
+        context,
+    )
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["current_directory"] == project.absolute_path
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["claude_session_id"] = "topic-202-session"
+
+    await orchestrator._inject_deps(topic_202_handler)(
+        _forum_update(202),
+        context,
+    )
+
+    thread_state = context.user_data["thread_state"]
+    assert thread_state["-1001234567890:101"]["current_directory"] == str(topic_101_dir)
+    assert thread_state["-1001234567890:101"]["claude_session_id"] == (
+        "topic-101-session"
+    )
+    assert thread_state["-1001234567890:202"]["current_directory"] == str(
+        project.absolute_path
+    )
+    assert thread_state["-1001234567890:202"]["claude_session_id"] == (
+        "topic-202-session"
+    )
+
+
+async def test_general_forum_topic_without_message_thread_id_uses_thread_one(
+    group_thread_settings, deps, project
+):
+    """Telegram omits message_thread_id for General; wrapper must route it as 1."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+    manager = _manager_for(project)
+    deps["project_threads_manager"] = manager
+    context = _context()
+
+    async def handler(update, context):
+        assert context.user_data["_thread_context"]["message_thread_id"] == 1
+        context.user_data["claude_session_id"] = "general-session"
+
+    await orchestrator._inject_deps(handler)(_forum_update(None), context)
+
+    manager.resolve_project.assert_awaited_once_with(-1001234567890, 1)
+    assert (
+        context.user_data["thread_state"]["-1001234567890:1"]["claude_session_id"]
+        == "general-session"
+    )
+
+
+async def test_disabled_project_threads_still_isolate_forum_topic_state(
+    disabled_thread_settings, deps
+):
+    """ENABLE_PROJECT_THREADS=false scopes sessions by forum topic without manager."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    manager = MagicMock()
+    manager.resolve_project = AsyncMock()
+    deps["project_threads_manager"] = manager
+    context = _context()
+    topic_101_dir = disabled_thread_settings.approved_directory / "topic101"
+    topic_101_dir.mkdir()
+
+    async def topic_101_handler(update, context):
+        assert context.user_data["current_directory"] == (
+            disabled_thread_settings.approved_directory
+        )
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["current_directory"] = topic_101_dir
+        context.user_data["claude_session_id"] = "topic-101-session"
+
+    await orchestrator._inject_deps(topic_101_handler)(_forum_update(101), context)
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["current_directory"] == (
+            disabled_thread_settings.approved_directory
+        )
+        assert context.user_data["claude_session_id"] is None
+        context.user_data["claude_session_id"] = "topic-202-session"
+
+    await orchestrator._inject_deps(topic_202_handler)(_forum_update(202), context)
+
+    thread_state = context.user_data["thread_state"]
+    manager.resolve_project.assert_not_called()
+    assert thread_state["-1001234567890:101"]["current_directory"] == str(topic_101_dir)
+    assert thread_state["-1001234567890:101"]["claude_session_id"] == (
+        "topic-101-session"
+    )
+    assert thread_state["-1001234567890:202"]["current_directory"] == str(
+        disabled_thread_settings.approved_directory
+    )
+    assert thread_state["-1001234567890:202"]["claude_session_id"] == (
+        "topic-202-session"
+    )
+
+
+async def test_disabled_project_threads_new_command_is_topic_local(
+    disabled_thread_settings, deps
+):
+    """/new with generic topic scoping must not leak force_new_session."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    context = _context(
+        {
+            "thread_state": {
+                "-1001234567890:101": {
+                    "current_directory": str(
+                        disabled_thread_settings.approved_directory
+                    ),
+                    "claude_session_id": "topic-101-old",
+                },
+                "-1001234567890:202": {
+                    "current_directory": str(
+                        disabled_thread_settings.approved_directory
+                    ),
+                    "claude_session_id": "topic-202-old",
+                },
+            }
+        }
+    )
+
+    await orchestrator._inject_deps(orchestrator.agentic_new)(
+        _forum_update(101),
+        context,
+    )
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["claude_session_id"]
+        is None
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["force_new_session"]
+        is True
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["session_started"]
+        is True
+    )
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["claude_session_id"] == "topic-202-old"
+        assert context.user_data.get("force_new_session") is not True
+        assert context.user_data.get("session_started") is not True
+
+    await orchestrator._inject_deps(topic_202_handler)(_forum_update(202), context)
+
+    assert (
+        "force_new_session"
+        not in context.user_data["thread_state"]["-1001234567890:202"]
+    )
+    assert (
+        "session_started" not in context.user_data["thread_state"]["-1001234567890:202"]
+    )
+
+
+async def test_private_chat_without_thread_keeps_unscoped_behavior(
+    disabled_thread_settings, deps
+):
+    """Plain private chats do not create generic thread context."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    context = _context()
+
+    async def handler(update, context):
+        context.user_data["claude_session_id"] = "private-session"
+
+    await orchestrator._inject_deps(handler)(_private_update_without_thread(), context)
+
+    assert "_thread_context" not in context.user_data
+    assert "thread_state" not in context.user_data
+
+
+async def test_direct_message_topic_uses_generic_thread_state(
+    disabled_thread_settings, deps
+):
+    """Direct-message topics with topic_id get the same generic isolation."""
+    orchestrator = MessageOrchestrator(disabled_thread_settings, deps)
+    context = _context()
+
+    async def handler(update, context):
+        assert context.user_data["_thread_context"]["state_key"] == "12345:909"
+        context.user_data["claude_session_id"] = "dm-topic-session"
+
+    await orchestrator._inject_deps(handler)(
+        _direct_message_topic_update(909),
+        context,
+    )
+
+    assert context.user_data["thread_state"]["12345:909"]["claude_session_id"] == (
+        "dm-topic-session"
+    )
+
+
+async def test_agentic_new_session_flags_are_topic_local(
+    group_thread_settings, deps, project
+):
+    """/new state is persisted only for the current forum topic."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+    manager = _manager_for(project)
+    deps["project_threads_manager"] = manager
+    context = _context(
+        {
+            "thread_state": {
+                "-1001234567890:101": {
+                    "current_directory": str(project.absolute_path),
+                    "claude_session_id": "topic-101-old",
+                },
+                "-1001234567890:202": {
+                    "current_directory": str(project.absolute_path),
+                    "claude_session_id": "topic-202-old",
+                },
+            }
+        }
+    )
+
+    await orchestrator._inject_deps(orchestrator.agentic_new)(
+        _forum_update(101),
+        context,
+    )
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["claude_session_id"]
+        is None
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["force_new_session"]
+        is True
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:101"]["session_started"]
+        is True
+    )
+
+    async def topic_202_handler(update, context):
+        assert context.user_data["claude_session_id"] == "topic-202-old"
+        assert context.user_data.get("force_new_session") is not True
+        assert context.user_data.get("session_started") is not True
+
+    await orchestrator._inject_deps(topic_202_handler)(
+        _forum_update(202),
+        context,
+    )
+
+    assert (
+        "force_new_session"
+        not in context.user_data["thread_state"]["-1001234567890:202"]
+    )
+    assert (
+        "session_started" not in context.user_data["thread_state"]["-1001234567890:202"]
+    )

--- a/tests/unit/test_bot/test_thread_mode_handlers.py
+++ b/tests/unit/test_bot/test_thread_mode_handlers.py
@@ -142,7 +142,98 @@ async def test_callback_cd_stays_within_project_root(thread_settings):
     await callback.handle_cd_callback(query, "..", context)
 
     assert context.user_data["current_directory"] == project_root
+    assert context.user_data["claude_session_id"] is None
+    context.bot_data["claude_integration"]._find_resumable_session.assert_not_called()
     query.edit_message_text.assert_called_once()
+
+
+async def test_continue_command_does_not_global_resume_in_thread_context(
+    thread_settings,
+):
+    """Classic /continue should not continue a global session from a new topic."""
+    settings, project_root = thread_settings
+    claude_integration = AsyncMock()
+    claude_integration.continue_session = AsyncMock()
+
+    update = MagicMock()
+    update.effective_user.id = 1
+    update.message.reply_text = AsyncMock(return_value=AsyncMock())
+
+    context = MagicMock()
+    context.args = []
+    context.bot_data = {
+        "settings": settings,
+        "audit_logger": None,
+        "claude_integration": claude_integration,
+    }
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": None,
+    }
+
+    await command.continue_session(update, context)
+
+    claude_integration.continue_session.assert_not_called()
+
+
+async def test_continue_callback_does_not_global_resume_in_thread_context(
+    thread_settings,
+):
+    """Classic continue callback should stay topic-local."""
+    settings, project_root = thread_settings
+    claude_integration = AsyncMock()
+    claude_integration.continue_session = AsyncMock()
+
+    query = MagicMock()
+    query.from_user.id = 1
+    query.edit_message_text = AsyncMock()
+
+    context = MagicMock()
+    context.bot_data = {"settings": settings, "claude_integration": claude_integration}
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": None,
+    }
+
+    await callback._handle_continue_action(query, context)
+
+    claude_integration.continue_session.assert_not_called()
+
+
+async def test_quick_action_forces_new_session_for_new_thread_context(thread_settings):
+    """Quick actions must not auto-resume a global session in a new topic."""
+    settings, project_root = thread_settings
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(
+        return_value=SimpleNamespace(session_id="quick-topic-session", content="ok")
+    )
+    quick_actions = SimpleNamespace(
+        actions={"qa": SimpleNamespace(icon="⚡", name="QA", prompt="run qa")}
+    )
+
+    query = MagicMock()
+    query.from_user.id = 1
+    query.edit_message_text = AsyncMock()
+    query.message.reply_text = AsyncMock()
+
+    context = MagicMock()
+    context.bot_data = {
+        "settings": settings,
+        "quick_actions": quick_actions,
+        "claude_integration": claude_integration,
+    }
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": None,
+    }
+
+    await callback.handle_quick_action_callback(query, "qa", context)
+
+    assert claude_integration.run_command.call_args.kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "quick-topic-session"
 
 
 async def test_start_private_mode_triggers_auto_sync(thread_settings):

--- a/tests/unit/test_bot/test_thread_mode_handlers.py
+++ b/tests/unit/test_bot/test_thread_mode_handlers.py
@@ -177,6 +177,38 @@ async def test_continue_command_does_not_global_resume_in_thread_context(
     claude_integration.continue_session.assert_not_called()
 
 
+async def test_status_does_not_show_global_resumable_session_in_thread_context(
+    thread_settings,
+):
+    """Classic /status should not surface another topic's resumable session."""
+    settings, project_root = thread_settings
+    claude_integration = AsyncMock()
+    claude_integration._find_resumable_session = AsyncMock()
+
+    update = MagicMock()
+    update.effective_user.id = 1
+    update.message.date.strftime.return_value = "12:00:00 UTC"
+    update.message.reply_text = AsyncMock()
+
+    context = MagicMock()
+    context.bot_data = {
+        "settings": settings,
+        "rate_limiter": None,
+        "claude_integration": claude_integration,
+    }
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": None,
+    }
+
+    await command.session_status(update, context)
+
+    claude_integration._find_resumable_session.assert_not_called()
+    sent_text = update.message.reply_text.call_args.args[0]
+    assert "Session will auto-resume" not in sent_text
+
+
 async def test_continue_callback_does_not_global_resume_in_thread_context(
     thread_settings,
 ):

--- a/tests/unit/test_bot/test_thread_mode_handlers.py
+++ b/tests/unit/test_bot/test_thread_mode_handlers.py
@@ -1,11 +1,12 @@
 """Tests for thread mode handler constraints."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.bot.handlers import callback, command
+from src.bot.handlers import callback, command, message
 from src.config import create_test_config
 
 
@@ -60,6 +61,60 @@ async def test_command_cd_stays_within_project_root(thread_settings):
     await command.change_directory(update, context)
 
     assert context.user_data["current_directory"] == project_root
+    assert context.user_data["claude_session_id"] is None
+    context.bot_data["claude_integration"]._find_resumable_session.assert_not_called()
+
+
+async def test_classic_text_forces_new_session_for_new_thread_context(thread_settings):
+    """Classic text handler must not auto-resume a global session in a new topic."""
+    settings, project_root = thread_settings
+
+    progress_msg = AsyncMock()
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(
+        return_value=SimpleNamespace(session_id="classic-topic-session", content="ok")
+    )
+
+    update = MagicMock()
+    update.effective_user.id = 1
+    update.message.text = "remember banana"
+    update.message.message_id = 10
+    update.message.chat.send_action = AsyncMock()
+    update.message.reply_text = AsyncMock(return_value=progress_msg)
+
+    context = MagicMock()
+    context.bot_data = {
+        "settings": settings,
+        "rate_limiter": None,
+        "audit_logger": None,
+        "storage": None,
+        "claude_integration": claude_integration,
+    }
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": None,
+    }
+
+    await message.handle_text_message(update, context)
+
+    assert claude_integration.run_command.call_args.kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "classic-topic-session"
+
+
+async def test_classic_thread_force_new_helper_covers_non_text_entrypoints(
+    thread_settings,
+):
+    """Document/photo/voice handlers share the same thread auto-resume guard."""
+    _, project_root = thread_settings
+    context = MagicMock()
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": None,
+    }
+
+    assert message._should_force_new_claude_session(context, None) is True
 
 
 async def test_callback_cd_stays_within_project_root(thread_settings):

--- a/tests/unit/test_bot/test_thread_mode_handlers.py
+++ b/tests/unit/test_bot/test_thread_mode_handlers.py
@@ -268,6 +268,44 @@ async def test_quick_action_forces_new_session_for_new_thread_context(thread_set
     assert context.user_data["claude_session_id"] == "quick-topic-session"
 
 
+async def test_quick_action_consumes_pending_force_new_session(thread_settings):
+    """Quick actions after /new must consume the one-shot force-new flag."""
+    settings, project_root = thread_settings
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(
+        return_value=SimpleNamespace(session_id="quick-topic-session", content="ok")
+    )
+    quick_actions = SimpleNamespace(
+        actions={"qa": SimpleNamespace(icon="⚡", name="QA", prompt="run qa")}
+    )
+
+    query = MagicMock()
+    query.from_user.id = 1
+    query.edit_message_text = AsyncMock()
+    query.message.reply_text = AsyncMock()
+
+    context = MagicMock()
+    context.bot_data = {
+        "settings": settings,
+        "quick_actions": quick_actions,
+        "claude_integration": claude_integration,
+    }
+    context.user_data = {
+        "current_directory": project_root,
+        "_thread_context": {"project_root": str(project_root)},
+        "claude_session_id": "old-topic-session",
+        "force_new_session": True,
+    }
+
+    await callback.handle_quick_action_callback(query, "qa", context)
+
+    kwargs = claude_integration.run_command.call_args.kwargs
+    assert kwargs["session_id"] == "old-topic-session"
+    assert kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "quick-topic-session"
+    assert context.user_data["force_new_session"] is False
+
+
 async def test_start_private_mode_triggers_auto_sync(thread_settings):
     """Private mode /start auto-syncs project topics for current private chat."""
     settings, _ = thread_settings

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -376,6 +376,192 @@ async def test_agentic_text_forces_new_session_for_new_thread_context(
     assert context.user_data["claude_session_id"] == "topic-session-abc"
 
 
+async def test_agentic_media_forces_new_session_for_new_thread_context(
+    agentic_settings, deps
+):
+    """Media-derived first messages in a topic must not auto-resume another topic."""
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+    mock_response = MagicMock()
+    mock_response.session_id = "topic-media-session"
+    mock_response.content = "Fresh media topic response"
+    mock_response.tools_used = []
+
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(return_value=mock_response)
+
+    update = MagicMock()
+    update.message.message_id = 10
+    update.message.reply_text = AsyncMock()
+
+    progress_msg = AsyncMock()
+    progress_msg.delete = AsyncMock()
+
+    chat = MagicMock()
+    chat.send_action = AsyncMock()
+
+    context = MagicMock()
+    context.user_data = {
+        "current_directory": agentic_settings.approved_directory,
+        "claude_session_id": None,
+        "_thread_context": {
+            "chat_id": -1001234567890,
+            "message_thread_id": 303,
+            "state_key": "-1001234567890:303",
+        },
+    }
+    context.bot_data = {
+        "settings": agentic_settings,
+        "claude_integration": claude_integration,
+        "rate_limiter": None,
+        "audit_logger": None,
+    }
+
+    await orchestrator._handle_agentic_media_message(
+        update=update,
+        context=context,
+        prompt="Describe this image",
+        progress_msg=progress_msg,
+        user_id=123,
+        chat=chat,
+        images=[{"type": "base64", "media_type": "image/png", "data": "abc"}],
+    )
+
+    claude_integration.run_command.assert_called_once()
+    assert claude_integration.run_command.call_args.kwargs["session_id"] is None
+    assert claude_integration.run_command.call_args.kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "topic-media-session"
+
+
+async def test_agentic_document_forces_new_session_for_new_thread_context(
+    agentic_settings, deps
+):
+    """Document first messages in a topic must not auto-resume another topic."""
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+    mock_response = MagicMock()
+    mock_response.session_id = "topic-document-session"
+    mock_response.content = "Fresh document topic response"
+    mock_response.tools_used = []
+
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(return_value=mock_response)
+
+    file_mock = AsyncMock()
+    file_mock.download_as_bytearray = AsyncMock(return_value=b"hello from document")
+
+    document = AsyncMock()
+    document.file_name = "note.txt"
+    document.file_size = 100
+    document.get_file = AsyncMock(return_value=file_mock)
+
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.message.document = document
+    update.message.caption = None
+    update.message.message_id = 11
+    update.message.reply_text = AsyncMock()
+    update.message.chat.send_action = AsyncMock()
+
+    progress_msg = AsyncMock()
+    progress_msg.delete = AsyncMock()
+    update.message.reply_text.return_value = progress_msg
+
+    context = MagicMock()
+    context.user_data = {
+        "current_directory": agentic_settings.approved_directory,
+        "claude_session_id": None,
+        "_thread_context": {
+            "chat_id": -1001234567890,
+            "message_thread_id": 304,
+            "state_key": "-1001234567890:304",
+        },
+    }
+    context.bot_data = {
+        "settings": agentic_settings,
+        "claude_integration": claude_integration,
+        "security_validator": None,
+        "features": None,
+        "rate_limiter": None,
+        "audit_logger": None,
+    }
+
+    await orchestrator.agentic_document(update, context)
+
+    claude_integration.run_command.assert_called_once()
+    assert claude_integration.run_command.call_args.kwargs["session_id"] is None
+    assert claude_integration.run_command.call_args.kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "topic-document-session"
+
+
+async def test_agentic_repo_does_not_resume_global_session_in_thread_context(
+    agentic_settings, deps
+):
+    """Switching repos inside a topic must not import user+directory sessions."""
+    (agentic_settings.approved_directory / "repo_a").mkdir()
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+    claude_integration = AsyncMock()
+    existing = MagicMock()
+    existing.session_id = "global-session"
+    claude_integration._find_resumable_session = AsyncMock(return_value=existing)
+
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.message.text = "/repo repo_a"
+    update.message.reply_text = AsyncMock()
+
+    context = MagicMock()
+    context.user_data = {
+        "_thread_context": {"state_key": "-1001234567890:404"},
+        "claude_session_id": None,
+    }
+    context.bot_data = {"claude_integration": claude_integration}
+
+    await orchestrator.agentic_repo(update, context)
+
+    claude_integration._find_resumable_session.assert_not_called()
+    assert context.user_data["claude_session_id"] is None
+    assert context.user_data["current_directory"].name == "repo_a"
+    assert "session resumed" not in update.message.reply_text.call_args.args[0]
+
+
+async def test_cd_callback_does_not_resume_global_session_in_thread_context(
+    agentic_settings, deps
+):
+    """cd: callbacks inside a topic must not import user+directory sessions."""
+    (agentic_settings.approved_directory / "repo_b").mkdir()
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+    claude_integration = AsyncMock()
+    existing = MagicMock()
+    existing.session_id = "global-session"
+    claude_integration._find_resumable_session = AsyncMock(return_value=existing)
+
+    query = MagicMock()
+    query.data = "cd:repo_b"
+    query.from_user.id = 123
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    context = MagicMock()
+    context.user_data = {
+        "_thread_context": {"state_key": "-1001234567890:505"},
+        "claude_session_id": None,
+    }
+    context.bot_data = {"claude_integration": claude_integration}
+
+    await orchestrator._agentic_callback(update, context)
+
+    claude_integration._find_resumable_session.assert_not_called()
+    assert context.user_data["claude_session_id"] is None
+    assert context.user_data["current_directory"].name == "repo_b"
+    assert "session resumed" not in query.edit_message_text.call_args.args[0]
+
+
 async def test_agentic_callback_scoped_to_cd_pattern(agentic_settings, deps):
     """Agentic callback handler is registered with cd: pattern filter."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -322,6 +322,60 @@ async def test_agentic_text_calls_claude(agentic_settings, deps):
         assert call.kwargs.get("reply_markup") is None
 
 
+async def test_agentic_text_forces_new_session_for_new_thread_context(
+    agentic_settings, deps
+):
+    """A new Telegram topic must not auto-resume the user's latest cwd session."""
+    orchestrator = MessageOrchestrator(agentic_settings, deps)
+
+    mock_response = MagicMock()
+    mock_response.session_id = "topic-session-abc"
+    mock_response.content = "Fresh topic response"
+    mock_response.tools_used = []
+
+    claude_integration = AsyncMock()
+    claude_integration.run_command = AsyncMock(return_value=mock_response)
+
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.message.text = "What word did I give you?"
+    update.message.message_id = 1
+    update.message.chat.send_action = AsyncMock()
+    update.message.reply_text = AsyncMock()
+
+    progress_msg = AsyncMock()
+    progress_msg.delete = AsyncMock()
+    update.message.reply_text.return_value = progress_msg
+
+    context = MagicMock()
+    context.user_data = {
+        "current_directory": agentic_settings.approved_directory,
+        "claude_session_id": None,
+        "_thread_context": {
+            "chat_id": -1001234567890,
+            "message_thread_id": 202,
+            "state_key": "-1001234567890:202",
+            "project_root": str(agentic_settings.approved_directory),
+            "project_slug": None,
+            "project_name": None,
+        },
+    }
+    context.bot_data = {
+        "settings": agentic_settings,
+        "claude_integration": claude_integration,
+        "storage": None,
+        "rate_limiter": None,
+        "audit_logger": None,
+    }
+
+    await orchestrator.agentic_text(update, context)
+
+    claude_integration.run_command.assert_called_once()
+    assert claude_integration.run_command.call_args.kwargs["session_id"] is None
+    assert claude_integration.run_command.call_args.kwargs["force_new"] is True
+    assert context.user_data["claude_session_id"] == "topic-session-abc"
+
+
 async def test_agentic_callback_scoped_to_cd_pattern(agentic_settings, deps):
     """Agentic callback handler is registered with cd: pattern filter."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
@@ -789,6 +843,88 @@ async def test_thread_mode_loads_and_persists_thread_state(group_thread_settings
     assert (
         context.user_data["thread_state"]["-1001234567890:777"]["claude_session_id"]
         == "new-session"
+    )
+
+
+async def test_thread_mode_new_session_flag_is_isolated_per_topic(
+    group_thread_settings, deps
+):
+    """/new in one forum topic must not force a new Claude session in another."""
+    orchestrator = MessageOrchestrator(group_thread_settings, deps)
+
+    project_path = group_thread_settings.approved_directory / "project_a"
+    project = SimpleNamespace(
+        slug="project_a",
+        name="Project A",
+        absolute_path=project_path,
+    )
+
+    project_threads_manager = MagicMock()
+    project_threads_manager.resolve_project = AsyncMock(return_value=project)
+    project_threads_manager.guidance_message.return_value = "Use project thread"
+    deps["project_threads_manager"] = project_threads_manager
+
+    context = MagicMock()
+    context.bot_data = {}
+    context.user_data = {
+        "thread_state": {
+            "-1001234567890:777": {
+                "current_directory": str(project_path),
+                "claude_session_id": "topic-777-session",
+            },
+            "-1001234567890:888": {
+                "current_directory": str(project_path),
+                "claude_session_id": "topic-888-session",
+            },
+        }
+    }
+
+    message_777 = MagicMock()
+    message_777.message_thread_id = 777
+    message_777.reply_text = AsyncMock()
+    update_777 = MagicMock()
+    update_777.effective_chat.id = -1001234567890
+    update_777.effective_chat.is_forum = True
+    update_777.effective_message = message_777
+    update_777.message = message_777
+    update_777.callback_query = None
+
+    wrapped_new = orchestrator._inject_deps(orchestrator.agentic_new)
+    await wrapped_new(update_777, context)
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:777"]["claude_session_id"]
+        is None
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:777"]["force_new_session"]
+        is True
+    )
+
+    message_888 = MagicMock()
+    message_888.message_thread_id = 888
+    message_888.reply_text = AsyncMock()
+    update_888 = MagicMock()
+    update_888.effective_chat.id = -1001234567890
+    update_888.effective_chat.is_forum = True
+    update_888.effective_message = message_888
+    update_888.message = message_888
+    update_888.callback_query = None
+
+    async def assert_topic_888_context(update, context):
+        assert context.user_data["claude_session_id"] == "topic-888-session"
+        assert not context.user_data.get("force_new_session", False)
+        context.user_data["claude_session_id"] = "topic-888-next-session"
+
+    await orchestrator._inject_deps(assert_topic_888_context)(update_888, context)
+
+    assert (
+        context.user_data["thread_state"]["-1001234567890:888"]["claude_session_id"]
+        == "topic-888-next-session"
+    )
+    assert (
+        context.user_data["thread_state"]["-1001234567890:777"]["force_new_session"]
+        is True
     )
 
 


### PR DESCRIPTION
## Summary
- scope Telegram forum topic state by `chat_id:message_thread_id`
- prevent new topics from auto-resuming another topic's Claude session
- keep `/new` / session flags local to the active topic
- add regression coverage for generic forum topic isolation, General topic handling, DM topics, and Claude `force_new` routing

## Test plan
- `uv run --with black black --check src/bot/orchestrator.py tests/unit/test_orchestrator.py tests/unit/test_bot/test_orchestrator_thread_context.py`
- `uv run pytest tests/unit/test_orchestrator.py::test_agentic_text_forces_new_session_for_new_thread_context tests/unit/test_bot/test_orchestrator_thread_context.py -q`
- `uv run pytest tests/unit/test_bot -q`
- `git diff --check`

## Notes
This fixes a context leak where a brand-new Telegram topic had no `claude_session_id`, causing the Claude integration to auto-resume the latest session for the same user and working directory.
